### PR TITLE
healer: fix issue #132 - Java Maven sandbox docker test

### DIFF
--- a/e2e-smoke/java-maven/src/main/java/com/flowhealer/Add.java
+++ b/e2e-smoke/java-maven/src/main/java/com/flowhealer/Add.java
@@ -4,6 +4,6 @@ public final class Add {
     private Add() {}
 
     public static int add(int left, int right) {
-        return left + right;
+        return Math.addExact(left, right);
     }
 }

--- a/e2e-smoke/java-maven/src/test/java/com/flowhealer/AddTest.java
+++ b/e2e-smoke/java-maven/src/test/java/com/flowhealer/AddTest.java
@@ -1,6 +1,7 @@
 package com.flowhealer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -8,5 +9,23 @@ class AddTest {
     @Test
     void addReturnsSum() {
         assertEquals(5, Add.add(2, 3));
+    }
+
+    @Test
+    void addHandlesRegressionCases() {
+        assertEquals(5, Add.add(3, 2));
+        assertEquals(7, Add.add(7, 0));
+        assertEquals(7, Add.add(0, 7));
+        assertEquals(42, Add.add(20, 22));
+    }
+
+    @Test
+    void addHandlesUpperBoundWithoutOverflow() {
+        assertEquals(Integer.MAX_VALUE, Add.add(Integer.MAX_VALUE - 1, 1));
+    }
+
+    @Test
+    void addThrowsOnOverflow() {
+        assertThrows(ArithmeticException.class, () -> Add.add(Integer.MAX_VALUE, 1));
     }
 }


### PR DESCRIPTION
Automated healer proposal for issue #132.

- Verifier: passed
- Targeted/full test gates: {'mode': 'docker_only', 'failed_tests': 0, 'targeted_tests': [], 'language_detected': 'java_maven', 'language_effective': 'java_maven', 'docker_image_effective': 'maven:3.9-eclipse-temurin-17', 'execution_root': 'e2e-smoke/java-maven', 'execution_root_source': 'issue', 'local_gate_policy': 'auto', 'docker_full_exit_code': 0, 'docker_full_output_tail': "Unable to find image 'maven:3.9-eclipse-temurin-17' locally\n3.9-eclipse-temurin-17: Pulling from library/maven\n124a23849ab3: Pulling fs layer\n9d717464f6e3: Pulling fs layer\n73b865274a2a: Pulling fs layer\na701ba1e133c: Pulling fs layer\n26e934bbfb37: Pulling fs layer\na37f0ae27eb7: Download complete\n124a23849ab3: Download complete\n093992351437: Download complete\n73b865274a2a: Download complete\n9d717464f6e3: Download complete\na701ba1e133c: Download complete\n26e934bbfb37: Download complete\n26e934bbfb37: Pull complete\n124a23849ab3: Pull complete\n73b865274a2a: Pull complete\n9d717464f6e3: Pull complete\na701ba1e133c: Pull complete\nDigest: sha256:a0603aab698040d9c94259f379ec0487da1678560748d6c7508483034033c53d\nStatus: Downloaded newer image for maven:3.9-eclipse-temurin-17", 'docker_full_status': 'passed'}
