### PR TITLE
healer: fix issue #158 - Python sandbox negative-number regression coverage

### DIFF
--- a/e2e-smoke/python/smoke_math.py
+++ b/e2e-smoke/python/smoke_math.py
@@ -1,4 +1,5 @@
 """Smoke-math fixture used by the Python sandbox tests."""
 
 def add(a: int, b: int) -> int:
+    """Return the arithmetic sum, including negative operands."""
     return a + b

--- a/e2e-smoke/python/tests/test_smoke_math.py
+++ b/e2e-smoke/python/tests/test_smoke_math.py
@@ -1,6 +1,8 @@
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
+import pytest
+
 
 def _load_smoke_math():
     module_path = Path(__file__).resolve().parents[1] / "smoke_math.py"
@@ -15,5 +17,14 @@ def _load_smoke_math():
 smoke_math = _load_smoke_math()
 
 
-def test_add_returns_sum() -> None:
-    assert smoke_math.add(2, 3) == 5
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    [
+        (2, 3, 5),
+        (-2, 3, 1),
+        (2, -3, -1),
+        (-2, -3, -5),
+    ],
+)
+def test_add_returns_sum(left: int, right: int, expected: int) -> None:
+    assert smoke_math.add(left, right) == expected


### PR DESCRIPTION
Automated healer proposal for issue #158.

- Verifier: passed
- Targeted/full test gates: {'mode': 'docker_only', 'failed_tests': 0, 'targeted_tests': ['tests/test_smoke_math.py'], 'language_detected': 'python', 'language_effective': 'python', 'docker_image_effective': 'python:3.11-slim', 'execution_root': 'e2e-smoke/python', 'execution_root_source': 'issue', 'local_gate_policy': 'auto', 'docker_targeted_exit_code': 0, 'docker_targeted_output_tail': "....                                                                     [100%]\n4 passed in 0.01s\n\nWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\nWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv", 'docker_targeted_status': 'passed', 'docker_full_exit_code': 0, 'docker_full_output_tail': "....                                                                     [100%]\n4 passed in 0.01s\n\nWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\nWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv", 'docker_full_status': 'passed', 'workspace_status': {'execution_root': 'e2e-smoke/python', 'staged_paths': ['e2e-smoke/python/smoke_math.py', 'e2e-smoke/python/tests/test_smoke_math.py'], 'unstaged_paths': [], 'untracked_paths': [], 'contamination_paths': [], 'cleanup_performed': False, 'cleaned_paths': [], 'cleanup_cycles_used': 0}}
