### PR TITLE
healer: fix issue #142 - Python sandbox negative-number regression coverage

### DIFF
--- a/e2e-smoke/python/tests/test_smoke_math.py
+++ b/e2e-smoke/python/tests/test_smoke_math.py
@@ -17,3 +17,8 @@ smoke_math = _load_smoke_math()
 
 def test_add_returns_sum() -> None:
     assert smoke_math.add(2, 3) == 5
+
+
+def test_add_supports_negative_numbers() -> None:
+    assert smoke_math.add(-2, 3) == 1
+    assert smoke_math.add(-4, -6) == -10


### PR DESCRIPTION
Automated healer proposal for issue #142.

- Verifier: passed
- Targeted/full test gates: {'mode': 'local_then_docker', 'failed_tests': 0, 'targeted_tests': ['tests/test_smoke_math.py'], 'language_detected': 'python', 'language_effective': 'python', 'docker_image_effective': 'python:3.11-slim', 'execution_root': 'e2e-smoke/python', 'execution_root_source': 'issue', 'local_gate_policy': 'auto', 'local_targeted_exit_code': 0, 'local_targeted_output_tail': '..                                                                       [100%]\n2 passed in 0.01s', 'local_targeted_status': 'passed', 'docker_targeted_exit_code': 0, 'docker_targeted_output_tail': "..                                                                       [100%]\n2 passed in 0.01s\n\nWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\nWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv", 'docker_targeted_status': 'passed', 'local_full_exit_code': 0, 'local_full_output_tail': '..                                                                       [100%]\n2 passed in 0.01s', 'local_full_status': 'passed', 'docker_full_exit_code': 0, 'docker_full_output_tail': "..                                                                       [100%]\n2 passed in 0.01s\n\nWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\nWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv", 'docker_full_status': 'passed', 'workspace_status': {'execution_root': 'e2e-smoke/python', 'staged_paths': ['e2e-smoke/python/tests/test_smoke_math.py'], 'unstaged_paths': [], 'untracked_paths': [], 'contamination_paths': [], 'cleanup_performed': False, 'cleaned_paths': [], 'cleanup_cycles_used': 0}}
