### PR TITLE
healer: fix issue #151 - Swift sandbox extra-addition regression coverage

### DIFF
--- a/e2e-smoke/swift/Tests/FlowHealerAddTests/AddTests.swift
+++ b/e2e-smoke/swift/Tests/FlowHealerAddTests/AddTests.swift
@@ -4,3 +4,7 @@ import Testing
 @Test func addAddsNumbers() {
     #expect(add(2, 3) == 5)
 }
+
+@Test func addAddsLargerNumbers() {
+    #expect(add(123, 456) == 579)
+}


### PR DESCRIPTION
Automated Flow Healer proposal for issue #151.

### Verification
- Verifier: `Scoped change is appropriately narrow: only e2e-smoke/swift/Tests/FlowHealerAddTests/AddTests.swift was updated to add a second regression test for larger positive operands (`add(123, 456) == 579`), which satisfies the request for another addition-behavior...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_then_docker`
- Language: `swift`
- Execution root: `e2e-smoke/swift`
- Local full gate: `passed`
- Docker full gate: `skipped` (reason `docker_unsupported_for_language`)
