### PR TITLE
healer: fix issue #200 - Python FastAPI sandbox: repository copy safety regression

### DIFF
--- a/e2e-apps/python-fastapi/app/__init__.py
+++ b/e2e-apps/python-fastapi/app/__init__.py
@@ -1,0 +1,1 @@
+"""Python FastAPI sandbox application package."""

--- a/e2e-apps/python-fastapi/app/repository.py
+++ b/e2e-apps/python-fastapi/app/repository.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class ServiceRecord:
+    service_id: str
+    name: str
+    tags: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class ServiceRepository:
+    def __init__(self, services: list[ServiceRecord] | None = None) -> None:
+        self._services = deepcopy(services) if services is not None else []
+
+    def add(self, service: ServiceRecord) -> ServiceRecord:
+        stored_service = deepcopy(service)
+        self._services.append(stored_service)
+        return deepcopy(stored_service)
+
+    def list_services(self) -> list[ServiceRecord]:
+        return deepcopy(self._services)

--- a/e2e-apps/python-fastapi/app/service.py
+++ b/e2e-apps/python-fastapi/app/service.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from app.repository import ServiceRecord, ServiceRepository
+
+
+class DomainService:
+    def __init__(self, repository: ServiceRepository) -> None:
+        self._repository = repository
+
+    def list_services(self) -> list[ServiceRecord]:
+        return deepcopy(self._repository.list_services())

--- a/e2e-apps/python-fastapi/pyproject.toml
+++ b/e2e-apps/python-fastapi/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/e2e-apps/python-fastapi/tests/test_domain_service.py
+++ b/e2e-apps/python-fastapi/tests/test_domain_service.py
@@ -1,0 +1,53 @@
+from app.repository import ServiceRecord, ServiceRepository
+from app.service import DomainService
+
+
+def test_repository_list_services_returns_detached_records() -> None:
+    repository = ServiceRepository(
+        [
+            ServiceRecord(
+                service_id="svc-1",
+                name="billing",
+                tags=["core"],
+                metadata={"region": "us-west-2"},
+            )
+        ]
+    )
+
+    listed_services = repository.list_services()
+    listed_services[0].tags.append("mutated")
+    listed_services[0].metadata["region"] = "eu-central-1"
+    listed_services.append(ServiceRecord(service_id="svc-2", name="analytics"))
+
+    fresh_services = repository.list_services()
+
+    assert len(fresh_services) == 1
+    assert fresh_services[0].tags == ["core"]
+    assert fresh_services[0].metadata == {"region": "us-west-2"}
+
+
+def test_domain_service_list_services_returns_detached_records() -> None:
+    repository = ServiceRepository(
+        [
+            ServiceRecord(
+                service_id="svc-1",
+                name="billing",
+                tags=["core"],
+                metadata={"region": "us-west-2"},
+            )
+        ]
+    )
+    service = DomainService(repository)
+
+    listed_services = service.list_services()
+    listed_services[0].name = "mutated"
+    listed_services[0].tags.append("mutated")
+    listed_services[0].metadata["region"] = "eu-central-1"
+
+    fresh_services = service.list_services()
+    repository_services = repository.list_services()
+
+    assert fresh_services[0].name == "billing"
+    assert fresh_services[0].tags == ["core"]
+    assert fresh_services[0].metadata == {"region": "us-west-2"}
+    assert repository_services[0].name == "billing"


### PR DESCRIPTION
Automated Flow Healer proposal for issue #200.

### Verification
- Verifier: `Patch is scoped to the FastAPI sandbox and satisfies the copy-safety regression: repository storage is isolated via deep copies on init/add/list, service list reads return detached data, and regression tests cover mutation of returned records plus nested fi...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_then_docker`
- Language: `python`
- Execution root: `e2e-apps/python-fastapi`
- Targeted tests: `tests/test_domain_service.py`
- Local full gate: `passed`
- Docker full gate: `passed`
