### PR TITLE
healer: fix issue #197 - Node Next sandbox: list endpoint contract regression coverage

### DIFF
--- a/e2e-apps/node-next/app/api/todos/route.js
+++ b/e2e-apps/node-next/app/api/todos/route.js
@@ -1,0 +1,22 @@
+const todos = [
+  {
+    id: 1,
+    title: 'Ship stable list endpoint contract coverage',
+    completed: false,
+  },
+  {
+    id: 2,
+    title: 'Keep todo payloads flexible as data evolves',
+    completed: true,
+  },
+];
+
+export function listTodos() {
+  return todos.map((todo) => ({ ...todo }));
+}
+
+export async function GET() {
+  return Response.json({
+    todos: listTodos(),
+  });
+}

--- a/e2e-apps/node-next/package.json
+++ b/e2e-apps/node-next/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "flow-healer-node-next-sandbox",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "sh -c 'node --test tests/todo-service.test.js'"
+  }
+}

--- a/e2e-apps/node-next/tests/todo-service.test.js
+++ b/e2e-apps/node-next/tests/todo-service.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { GET, listTodos } from '../app/api/todos/route.js';
+
+test('listTodos returns todo objects with the stable fields the API exposes', () => {
+  const todos = listTodos();
+
+  assert.ok(Array.isArray(todos));
+  assert.ok(todos.length > 0);
+
+  for (const todo of todos) {
+    assert.deepEqual(Object.keys(todo).sort(), ['completed', 'id', 'title']);
+    assert.equal(typeof todo.id, 'number');
+    assert.equal(typeof todo.title, 'string');
+    assert.equal(typeof todo.completed, 'boolean');
+  }
+});
+
+test('GET returns the stable list endpoint contract', async () => {
+  const response = await GET();
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+
+  const payload = await response.json();
+
+  assert.deepEqual(Object.keys(payload), ['todos']);
+  assert.ok(Array.isArray(payload.todos));
+  assert.deepEqual(payload.todos, listTodos());
+});


### PR DESCRIPTION
Automated Flow Healer proposal for issue #197.

### Verification
- Verifier: `Patch stays appropriately narrow for the Node Next sandbox and anchors the required route/test files. It adds stable contract coverage for the list endpoint without overfitting todo contents, and the provided local and docker `npm test -- --passWithNoTests`...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_then_docker`
- Language: `node`
- Execution root: `e2e-apps/node-next`
- Local full gate: `passed`
- Docker full gate: `passed`
