### PR TITLE
healer: fix issue #196 - Node Next sandbox: complete endpoint should be stable on repeated calls

### DIFF
--- a/e2e-apps/node-next/app/api/todos/[id]/complete/route.js
+++ b/e2e-apps/node-next/app/api/todos/[id]/complete/route.js
@@ -1,0 +1,20 @@
+import { completeTodo } from "../../../../../lib/todo-service.js";
+
+function json(body, init) {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "content-type": "application/json",
+    },
+    ...init,
+  });
+}
+
+export async function POST(_request, { params }) {
+  const todo = completeTodo(params.id);
+
+  if (!todo) {
+    return json({ error: "Todo not found" }, { status: 404 });
+  }
+
+  return json({ todo }, { status: 200 });
+}

--- a/e2e-apps/node-next/lib/todo-service.js
+++ b/e2e-apps/node-next/lib/todo-service.js
@@ -1,0 +1,43 @@
+const defaultTodos = [
+  {
+    id: "1",
+    title: "Ship stable completion endpoint",
+    completed: false,
+    completedAt: null,
+  },
+  {
+    id: "2",
+    title: "Keep repeated calls idempotent",
+    completed: false,
+    completedAt: null,
+  },
+];
+
+let todos = defaultTodos.map((todo) => ({ ...todo }));
+
+function cloneTodo(todo) {
+  return { ...todo };
+}
+
+export function listTodos() {
+  return todos.map(cloneTodo);
+}
+
+export function completeTodo(id) {
+  const todo = todos.find((entry) => entry.id === id);
+
+  if (!todo) {
+    return null;
+  }
+
+  if (!todo.completed) {
+    todo.completed = true;
+    todo.completedAt = new Date().toISOString();
+  }
+
+  return cloneTodo(todo);
+}
+
+export function resetTodosForTests(seed = defaultTodos) {
+  todos = seed.map((todo) => cloneTodo(todo));
+}

--- a/e2e-apps/node-next/package.json
+++ b/e2e-apps/node-next/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "node-next-sandbox",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node ./scripts/run-tests.js"
+  }
+}

--- a/e2e-apps/node-next/scripts/run-tests.js
+++ b/e2e-apps/node-next/scripts/run-tests.js
@@ -1,0 +1,11 @@
+import { spawnSync } from "node:child_process";
+
+const result = spawnSync(process.execPath, ["--test"], {
+  stdio: "inherit",
+});
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);

--- a/e2e-apps/node-next/tests/todo-service.test.js
+++ b/e2e-apps/node-next/tests/todo-service.test.js
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { completeTodo, resetTodosForTests } from "../lib/todo-service.js";
+
+test("completeTodo marks an incomplete todo complete", () => {
+  resetTodosForTests([
+    { id: "a", title: "One", completed: false, completedAt: null },
+  ]);
+
+  const todo = completeTodo("a");
+
+  assert.equal(todo?.completed, true);
+  assert.equal(typeof todo?.completedAt, "string");
+});
+
+test("completeTodo is stable when the same todo is completed repeatedly", () => {
+  resetTodosForTests([
+    { id: "a", title: "One", completed: false, completedAt: null },
+  ]);
+
+  const first = completeTodo("a");
+  const second = completeTodo("a");
+
+  assert.deepEqual(second, first);
+});
+
+test("completeTodo returns null when the todo does not exist", () => {
+  resetTodosForTests([]);
+
+  assert.equal(completeTodo("missing"), null);
+});


### PR DESCRIPTION
Automated Flow Healer proposal for issue #196.

### Verification
- Verifier: `The patch satisfies the issue: `completeTodo` is now idempotent, the complete route returns the same completed todo on repeated calls, and regression coverage was added for first completion, repeated completion, and missing ids. The extra `package.json` and...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_then_docker`
- Language: `node`
- Execution root: `e2e-apps/node-next`
- Local full gate: `passed`
- Docker full gate: `passed`
