### PR TITLE
healer: fix issue #195 - Node Next sandbox: reject blank todo titles

### DIFF
--- a/e2e-apps/node-next/app/api/todos/route.js
+++ b/e2e-apps/node-next/app/api/todos/route.js
@@ -1,4 +1,4 @@
-import { todoService } from "../../../lib/todo-service.js";
+import { normalizeTodoTitle, todoService } from "../../../lib/todo-service.js";
 
 export function listTodos() {
   return todoService.list().map((todo) => ({
@@ -22,8 +22,9 @@ export async function POST(request) {
   if (!payload || typeof payload !== "object" || typeof payload.title !== "string") {
     return Response.json({ error: "title_required" }, { status: 400 });
   }
+
   try {
-    const created = todoService.create(payload.title);
+    const created = todoService.create(normalizeTodoTitle(payload.title));
     return Response.json({ item: created }, { status: 201 });
   } catch (error) {
     return Response.json({ error: String(error.message || "create_failed") }, { status: 400 });

--- a/e2e-apps/node-next/lib/todo-service.js
+++ b/e2e-apps/node-next/lib/todo-service.js
@@ -9,13 +9,7 @@ export class TodoService {
   }
 
   create(title) {
-    if (typeof title !== "string") {
-      throw new Error("title_required");
-    }
-    const normalized = title.trim();
-    if (!normalized) {
-      throw new Error("title_required");
-    }
+    const normalized = normalizeTodoTitle(title);
     const todo = {
       id: String(this._nextId++),
       title: normalized,
@@ -39,6 +33,19 @@ export class TodoService {
     }
     return { ...todo };
   }
+}
+
+export function normalizeTodoTitle(title) {
+  if (typeof title !== "string") {
+    throw new Error("title_required");
+  }
+
+  const normalized = title.trim();
+  if (!normalized) {
+    throw new Error("title_required");
+  }
+
+  return normalized;
 }
 
 export const todoService = new TodoService();

--- a/e2e-apps/node-next/tests/todo-service.test.js
+++ b/e2e-apps/node-next/tests/todo-service.test.js
@@ -67,11 +67,12 @@ test("create rejects blank and non-string titles", () => {
 });
 
 test("POST rejects blank and malformed titles", async () => {
+  const todosBefore = listTodos().length;
   const blankResponse = await POST(
     new Request("http://localhost/api/todos", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ title: "   " }),
+      body: JSON.stringify({ title: "  \n\t  " }),
     }),
   );
   const malformedResponse = await POST(
@@ -86,4 +87,5 @@ test("POST rejects blank and malformed titles", async () => {
   assert.deepEqual(await blankResponse.json(), { error: "title_required" });
   assert.equal(malformedResponse.status, 400);
   assert.deepEqual(await malformedResponse.json(), { error: "title_required" });
+  assert.equal(listTodos().length, todosBefore);
 });


### PR DESCRIPTION
Automated Flow Healer proposal for issue #195.

### Verification
- Verifier: `Patch stays within Issue #195’s blank-title scope and only touches the three expected Node Next files. It hardens title validation by centralizing normalization in the service, reusing that normalization at the API boundary, and adds a regression test for w...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_then_docker`
- Language: `node`
- Execution root: `e2e-apps/node-next`
- Local full gate: `passed`
- Docker full gate: `passed`
