### PR TITLE
healer: fix issue #353 - Runner contract: completion artifact fallback behavior

### DIFF
--- a/src/flow_healer/healer_runner.py
+++ b/src/flow_healer/healer_runner.py
@@ -370,6 +370,15 @@ class HealerRunner:
                         task_spec=task_spec,
                     )
                     if no_workspace_change_retries_used >= 1:
+                        _materialize_completion_artifact(
+                            issue_id=issue_id,
+                            issue_title=issue_title,
+                            task_spec=task_spec,
+                            proposer_output=proposer_output,
+                            failure_class=failure_class,
+                            failure_reason=failure_reason,
+                            workspace=workspace,
+                        )
                         return HealerRunResult(
                             success=False,
                             failure_class=failure_class,
@@ -389,24 +398,43 @@ class HealerRunner:
                     no_workspace_change_retries_used += 1
                 if proposer_attempt >= max_retries or failure_class in _NON_RETRYABLE_FAILURES:
                     # Last-resort: write a completion artifact so the run has some output.
-                    if failure_class not in _NON_RETRYABLE_FAILURES and _materialize_completion_artifact(
-                        issue_id=issue_id,
-                        issue_title=issue_title,
-                        task_spec=task_spec,
-                        proposer_output=proposer_output,
-                        failure_class=failure_class,
-                        failure_reason=failure_reason,
-                        workspace=workspace,
-                    ) and _stage_workspace_changes(
-                        workspace,
-                        issue_title=issue_title,
-                        issue_body=issue_body,
-                        task_spec=task_spec,
-                        language=resolved_execution.language_effective,
-                    ):
-                        failure_class = ""
-                        failure_reason = ""
-                        break
+                    if failure_class not in _NON_RETRYABLE_FAILURES:
+                        wrote_completion_artifact = _materialize_completion_artifact(
+                            issue_id=issue_id,
+                            issue_title=issue_title,
+                            task_spec=task_spec,
+                            proposer_output=proposer_output,
+                            failure_class=failure_class,
+                            failure_reason=failure_reason,
+                            workspace=workspace,
+                        )
+                        if wrote_completion_artifact and _requires_non_artifact_diff(task_spec=task_spec):
+                            return HealerRunResult(
+                                success=False,
+                                failure_class=failure_class,
+                                failure_reason=failure_reason,
+                                failure_fingerprint=_execution_contract_failure_fingerprint(
+                                    failure_class=failure_class,
+                                    connector=self.connector,
+                                    task_spec=task_spec,
+                                ),
+                                proposer_output=proposer_output,
+                                diff_paths=[],
+                                diff_files=0,
+                                diff_lines=0,
+                                test_summary={},
+                                workspace_status=workspace_status,
+                            )
+                        if wrote_completion_artifact and _stage_workspace_changes(
+                            workspace,
+                            issue_title=issue_title,
+                            issue_body=issue_body,
+                            task_spec=task_spec,
+                            language=resolved_execution.language_effective,
+                        ):
+                            failure_class = ""
+                            failure_reason = ""
+                            break
                     return HealerRunResult(
                         success=False,
                         failure_class=failure_class,
@@ -549,7 +577,7 @@ class HealerRunner:
 
             if proposer_attempt >= max_retries:
                 # Last-resort: write a completion artifact so the run has some output.
-                if _materialize_completion_artifact(
+                wrote_completion_artifact = _materialize_completion_artifact(
                     issue_id=issue_id,
                     issue_title=issue_title,
                     task_spec=task_spec,
@@ -557,7 +585,25 @@ class HealerRunner:
                     failure_class=failure_class,
                     failure_reason=failure_reason,
                     workspace=workspace,
-                ) and _stage_workspace_changes(
+                )
+                if wrote_completion_artifact and _requires_non_artifact_diff(task_spec=task_spec):
+                    return HealerRunResult(
+                        success=False,
+                        failure_class=failure_class,
+                        failure_reason=failure_reason,
+                        failure_fingerprint=_execution_contract_failure_fingerprint(
+                            failure_class=failure_class,
+                            connector=self.connector,
+                            task_spec=task_spec,
+                        ),
+                        proposer_output=proposer_output,
+                        diff_paths=[],
+                        diff_files=0,
+                        diff_lines=0,
+                        test_summary={},
+                        workspace_status=workspace_status,
+                    )
+                if wrote_completion_artifact and _stage_workspace_changes(
                     workspace,
                     issue_title=issue_title,
                     issue_body=issue_body,
@@ -2619,7 +2665,10 @@ def _materialize_completion_artifact(
     workspace: Path,
 ) -> bool:
     """Write a structured run-summary artifact when the agent ran but produced no file changes."""
-    if failure_class not in _COMPLETION_ARTIFACT_NO_CHANGE_CLASSES:
+    if (
+        failure_class not in _COMPLETION_ARTIFACT_NO_CHANGE_CLASSES
+        and not _is_no_workspace_change_failure_class(failure_class)
+    ):
         return False
     output_text = (proposer_output or "").strip()
     if not output_text:

--- a/tests/test_healer_runner.py
+++ b/tests/test_healer_runner.py
@@ -2283,6 +2283,48 @@ def test_run_attempt_app_server_no_workspace_change_allows_only_one_same_thread_
     assert "this retry is strict" in connector.turns[1][1].lower()
 
 
+def test_run_attempt_app_server_writes_completion_artifact_for_repeated_prose_no_diff(tmp_path):
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    _init_git_repo(workspace)
+    (workspace / "demo.py").write_text("def add(a, b):\n    return a - b\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=workspace, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=workspace, check=True, capture_output=True, text=True)
+
+    app_server_cls = type("CodexAppServerConnector", (_RetryConnector,), {})
+    prose_output = "Updated demo.py to fix the bug and verified the result locally."
+    connector = app_server_cls([prose_output, prose_output])
+    runner = HealerRunner(connector, timeout_seconds=30, test_gate_mode="local_only")
+    runner.max_code_proposer_retries = 1
+
+    result = runner.run_attempt(
+        issue_id="915bb",
+        issue_title="Fix demo",
+        issue_body="Repair demo.py",
+        task_spec=HealerTaskSpec(
+            task_kind="fix",
+            output_mode="patch",
+            output_targets=("demo.py",),
+            tool_policy="repo_only",
+            validation_profile="code_change",
+        ),
+        workspace=workspace,
+        max_diff_files=5,
+        max_diff_lines=20,
+        max_failed_tests_allowed=0,
+        targeted_tests=[],
+    )
+
+    artifact = workspace / "docs" / "healer-runs" / "915bb-fix-demo.md"
+    assert result.success is False
+    assert artifact.exists()
+    content = artifact.read_text(encoding="utf-8")
+    assert "did not produce direct file changes" in content
+    assert result.failure_class == "no_workspace_change:connector_noop"
+    assert "no_workspace_change:connector_noop" in content
+    assert len(connector.turns) == 2
+
+
 def test_run_attempt_app_server_always_mode_accepts_lenient_named_target_fallback(monkeypatch, tmp_path):
     workspace = tmp_path / "repo"
     workspace.mkdir()


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #353.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Narrow, well-justified runner change. The patch specifically extends completion-artifact fallback to `no_workspace_change:*` failures and writes the artifact on repeated prose/no-diff retries without incorrectly treating docs-only output as a successful cod...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Targeted tests: `tests/test_healer_runner.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
