### PR TITLE
healer: fix issue #358 - Sandbox Python: preserve mixed-sign edge behavior

### DIFF
--- a/e2e-smoke/python/smoke_math.py
+++ b/e2e-smoke/python/smoke_math.py
@@ -96,19 +96,12 @@ def _is_additive_identity(value: int) -> bool:
     return value == 0
 
 
-def _operands_cancel_to_zero(left: int, right: int) -> bool:
-    """Return whether opposite-signed operands collapse onto additive identity."""
-    return left == -right
-
-
 def _add_normalized_operands(left: int, right: int) -> int:
     """Add normalized ints while preserving zero identity and sign semantics."""
     if _is_additive_identity(left):
         return _canonicalize_zero(right)
     if _is_additive_identity(right):
         return _canonicalize_zero(left)
-    if _operands_cancel_to_zero(left, right):
-        return 0
     return _canonicalize_zero(left + right)
 
 

--- a/e2e-smoke/python/tests/test_smoke_math.py
+++ b/e2e-smoke/python/tests/test_smoke_math.py
@@ -215,6 +215,41 @@ def test_add_canonicalizes_zero_when_signed_inputs_cancel(
 
 
 @pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    (
+        pytest.param(
+            10**80,
+            -(10**80) + 1,
+            1,
+            id="large_positive_and_negative_operands_keep_positive_edge",
+        ),
+        pytest.param(
+            -(10**80),
+            (10**80) - 1,
+            -1,
+            id="large_negative_and_positive_operands_keep_negative_edge",
+        ),
+        pytest.param(
+            f"+{10**80}",
+            str(-(10**80)),
+            0,
+            id="large_string_operands_cancel_to_canonical_zero",
+        ),
+    ),
+)
+def test_add_matches_python_int_arithmetic_for_large_mixed_sign_operands(
+    left: object,
+    right: object,
+    expected: int,
+) -> None:
+    """Mixed-sign edge cases should keep Python int arithmetic semantics."""
+    result = _call_add(left, right)
+    assert result == expected
+    assert result == _normalize_operand(left) + _normalize_operand(right)
+    assert type(result) is int
+
+
+@pytest.mark.parametrize(
     ("left", "right"),
     (
         pytest.param(-23, 23, id="ints_cancel_directly"),


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #358.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch is appropriately scoped to the sandbox Python smoke files, fixes the mixed-sign addition path by removing an unnecessary pre-check that could bypass normal integer arithmetic, and adds focused regression coverage for large mixed-sign operands plus can...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-smoke/python`
- Targeted tests: `tests/test_smoke_math.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
