### PR TITLE
healer: fix issue #516 - Easy: Sandbox batch 25 - FastAPI API response regression

### DIFF
--- a/e2e-apps/python-fastapi/app/api.py
+++ b/e2e-apps/python-fastapi/app/api.py
@@ -39,7 +39,7 @@ def _service_for(request_service: TodoService | None) -> TodoService:
 
 
 def list_todos(todo_service: TodoService | None = None) -> dict[str, object]:
-    return {"items": [item.as_dict() for item in _service_for(todo_service).list_todos()]}
+    return {"todos": [item.as_dict() for item in _service_for(todo_service).list_todos()]}
 
 
 def create_todo(

--- a/e2e-apps/python-fastapi/tests/test_api_contract.py
+++ b/e2e-apps/python-fastapi/tests/test_api_contract.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from app.api import complete_todo, create_app, create_todo, health
+from app.api import complete_todo, create_app, create_todo, health, list_todos
 
 
 def test_health_returns_ok_status() -> None:
@@ -16,6 +16,12 @@ def test_create_todo_rejects_blank_titles() -> None:
     error = exc_info.value
     assert getattr(error, "status_code", None) == 400
     assert getattr(error, "detail", "") == "title_required"
+
+
+def test_list_todos_returns_stable_todos_payload() -> None:
+    created = create_todo({"title": "Ship fix"})
+
+    assert list_todos() == {"todos": [created["item"]]}
 
 
 def test_complete_todo_raises_not_found_for_unknown_id() -> None:
@@ -50,5 +56,5 @@ def test_create_app_keeps_todo_state_isolated_per_app_instance() -> None:
     created = first_create({"title": "Ship fix"})
 
     assert created["item"]["id"] == "1"
-    assert first_list()["items"] == [created["item"]]
-    assert second_list()["items"] == []
+    assert first_list()["todos"] == [created["item"]]
+    assert second_list()["todos"] == []


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #516.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Renamed the list response key in `app/api.py` from `items` to `todos` to match the intended FastAPI contract, and updated the focused API contract tests to assert the stable payload shape. The patch stays narrowly scoped to the required FastAPI sandbox file...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/python-fastapi`
- Targeted tests: `tests/test_api_contract.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
