### PR TITLE
healer: fix issue #528 - Canary: Prosper chat billing summary helper

### DIFF
--- a/e2e-apps/prosper-chat/src/lib/plans.ts
+++ b/e2e-apps/prosper-chat/src/lib/plans.ts
@@ -23,6 +23,13 @@ export interface PlanConfig {
   cta: string;
 }
 
+export type BillingCycle = "monthly" | "annual";
+
+export interface PlanBillingSummary {
+  billedUpfront: number | null;
+  monthlyEquivalent: number;
+}
+
 export const PLANS: Record<PlanKey, PlanConfig> = {
   free: {
     name: "Starter",
@@ -80,6 +87,23 @@ export const PLANS: Record<PlanKey, PlanConfig> = {
 };
 
 export const PLAN_KEYS: PlanKey[] = ["free", "pro", "agency"];
+
+export function getPlanBillingSummary(
+  plan: PlanConfig,
+  billingCycle: BillingCycle,
+): PlanBillingSummary {
+  if (billingCycle === "annual") {
+    return {
+      billedUpfront: plan.annualPrice || null,
+      monthlyEquivalent: Math.round(plan.annualPrice / 12),
+    };
+  }
+
+  return {
+    billedUpfront: null,
+    monthlyEquivalent: plan.monthlyPrice,
+  };
+}
 
 export const COMPARISON_FEATURES = [
   { label: "Businesses", free: "1", pro: "1", agency: "Up to 10" },

--- a/e2e-apps/prosper-chat/src/test/plans.test.ts
+++ b/e2e-apps/prosper-chat/src/test/plans.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { PLANS, getPlanBillingSummary } from "@/lib/plans";
+
+describe("getPlanBillingSummary", () => {
+  it("returns a zero monthly equivalent for the free plan annual view", () => {
+    expect(getPlanBillingSummary(PLANS.free, "annual")).toEqual({
+      billedUpfront: null,
+      monthlyEquivalent: 0,
+    });
+  });
+
+  it("returns a rounded monthly equivalent and annual charge for paid annual plans", () => {
+    expect(getPlanBillingSummary(PLANS.pro, "annual")).toEqual({
+      billedUpfront: 490,
+      monthlyEquivalent: 41,
+    });
+  });
+});


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #528.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Adds a small exported billing summary helper in the requested plans module and focused tests for the free tier plus a paid annual plan. The change stays narrowly scoped to the named targets, handles annual monthly-equivalent derivation without UI special-ca...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-apps/prosper-chat`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
