### PR TITLE
healer: fix issue #508 - Medium: Sandbox batch 17 - Node Next service ID allocation regression

### DIFF
--- a/e2e-apps/node-next/lib/todo-service.js
+++ b/e2e-apps/node-next/lib/todo-service.js
@@ -1,7 +1,7 @@
 export class TodoService {
-  constructor() {
-    this._todos = [];
-    this._nextId = 1;
+  constructor(todos = []) {
+    this._todos = todos.map((todo) => ({ ...todo }));
+    this._nextId = getNextTodoId(this._todos);
   }
 
   list() {
@@ -10,6 +10,7 @@ export class TodoService {
 
   create(title) {
     const normalized = normalizeTodoTitle(title);
+    this._nextId = Math.max(this._nextId, getNextTodoId(this._todos));
     const todo = {
       id: String(this._nextId++),
       title: normalized,
@@ -48,6 +49,19 @@ export function normalizeTodoTitle(title) {
   }
 
   return normalized;
+}
+
+function getNextTodoId(todos) {
+  let maxId = 0;
+
+  for (const todo of todos) {
+    const numericId = Number.parseInt(String(todo?.id ?? ""), 10);
+    if (Number.isSafeInteger(numericId) && numericId > maxId) {
+      maxId = numericId;
+    }
+  }
+
+  return maxId + 1;
 }
 
 export function toPublicTodo(todo) {

--- a/e2e-apps/node-next/tests/todo-service.test.js
+++ b/e2e-apps/node-next/tests/todo-service.test.js
@@ -47,6 +47,33 @@ test("create assigns ids and trims title", () => {
   assert.equal(second.id, "2");
 });
 
+test("create advances past the highest existing todo id", () => {
+  const service = new TodoService([
+    {
+      id: "2",
+      title: "Already there",
+      completed: false,
+      createdAt: "2026-03-08T12:00:00.000Z",
+      completedAt: null,
+    },
+    {
+      id: "7",
+      title: "Highest id wins",
+      completed: true,
+      createdAt: "2026-03-08T12:01:00.000Z",
+      completedAt: "2026-03-08T12:02:00.000Z",
+    },
+  ]);
+
+  const created = service.create("Add the next item");
+
+  assert.equal(created.id, "8");
+  assert.deepEqual(
+    service.list().map((todo) => todo.id),
+    ["2", "7", "8"],
+  );
+});
+
 test("complete marks an item complete and records completedAt", () => {
   const service = new TodoService();
   const created = service.create("Harden retries");


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #508.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Todo ID allocation regression is fixed within the declared targets by seeding TodoService from existing todos and deriving the next ID from the highest current numeric todo ID. The added test covers creating a new todo after preloaded items with ids 2 and 7...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-apps/node-next`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
