### PR TITLE
healer: fix issue #576 - Prosper chat DB task 8: Prosper chat DB: admin lead visibility policies remain e

### DIFF
--- a/e2e-apps/prosper-chat/supabase/assertions/admin_lead_visibility.sql
+++ b/e2e-apps/prosper-chat/supabase/assertions/admin_lead_visibility.sql
@@ -1,0 +1,29 @@
+-- Assert explicit admin visibility remains configured for leads.
+SELECT
+  policyname,
+  coalesce(array_to_string(roles, ', '), 'ALL') AS roles,
+  cmd,
+  qual,
+  with_check
+FROM pg_policies
+WHERE schemaname = 'public'
+  AND tablename = 'leads';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'leads'
+      AND policyname = 'Admins can view all leads'
+      AND cmd = 'SELECT'
+      AND roles IS NOT NULL
+      AND roles @> ARRAY['authenticated']::name[]
+      AND position('has_role(auth.uid(),' in lower(qual)) > 0
+      AND position('admin' in lower(qual)) > 0
+  ) THEN
+    RAISE EXCEPTION 'Missing or misconfigured explicit admin lead visibility policy.';
+  END IF;
+END;
+$$;

--- a/e2e-apps/prosper-chat/supabase/migrations/20260301210456_0d5a18c3-28c7-4323-9b90-f6c53efb29d1.sql
+++ b/e2e-apps/prosper-chat/supabase/migrations/20260301210456_0d5a18c3-28c7-4323-9b90-f6c53efb29d1.sql
@@ -1,0 +1,16 @@
+-- Keep admin lead visibility explicitly modeled as a dedicated policy.
+DO $$
+BEGIN
+  IF to_regclass('public.leads') IS NULL THEN
+    RAISE NOTICE 'Skipping admin lead visibility migration: public.leads does not exist yet.';
+    RETURN;
+  END IF;
+
+  DROP POLICY IF EXISTS "Admins can view all leads" ON public.leads;
+
+  CREATE POLICY "Admins can view all leads"
+  ON public.leads
+  FOR SELECT TO authenticated
+  USING (public.has_role(auth.uid(), 'admin'));
+END;
+$$;


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #576.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `The patch is narrowly scoped to the required output targets and preserves existing behavior by recreating a dedicated explicit policy for admin lead visibility on `public.leads` (`FOR SELECT TO authenticated USING public.has_role(auth.uid(), 'admin')`) rath...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-apps/prosper-chat`
- Local full gate: `passed`
- Docker full gate: `skipped` (reason `explicit_validation_commands`)

_Built with a little hustle by Flow Healer 🤖✨_
