### PR TITLE
healer: fix issue #499 - Medium: Sandbox batch 8 - FastAPI API contract drift

### DIFF
--- a/e2e-apps/python-fastapi/app/api.py
+++ b/e2e-apps/python-fastapi/app/api.py
@@ -6,6 +6,8 @@ from .service import TodoItem, TodoService
 try:
     from fastapi import FastAPI, HTTPException
 except Exception:  # pragma: no cover - lightweight fallback for minimal environments
+    from types import SimpleNamespace
+
     class HTTPException(Exception):
         def __init__(self, *, status_code: int, detail: str) -> None:
             super().__init__(detail)
@@ -15,15 +17,26 @@ except Exception:  # pragma: no cover - lightweight fallback for minimal environ
     class FastAPI:  # type: ignore[override]
         def __init__(self, *, title: str) -> None:
             self.title = title
+            self.routes: list[SimpleNamespace] = []
+
+        def _route(self, path: str, methods: set[str], endpoint: object, status_code: int = 200) -> None:
+            self.routes.append(
+                SimpleNamespace(path=path, methods=methods, endpoint=endpoint, status_code=status_code)
+            )
 
         def get(self, _path: str):
             def decorator(func):
+                self._route(_path, {"GET"}, func, status_code=200)
                 return func
 
             return decorator
 
-        def post(self, _path: str):
+        def post(self, _path: str, **_kwargs: object):
             def decorator(func):
+                status_code = _kwargs.get("status_code", 200)
+                if not isinstance(status_code, int):
+                    status_code = 200
+                self._route(_path, {"POST"}, func, status_code=status_code)
                 return func
 
             return decorator
@@ -52,7 +65,10 @@ def _serialize_todo(item: TodoItem) -> dict[str, object]:
     }
 
 
-def _extract_title(payload: Mapping[str, object]) -> str:
+def _extract_title(payload: object) -> str:
+    if not isinstance(payload, Mapping):
+        return ""
+
     raw_title = payload.get("title", "")
     if not isinstance(raw_title, str):
         return ""
@@ -60,7 +76,7 @@ def _extract_title(payload: Mapping[str, object]) -> str:
 
 
 def create_todo(
-    payload: Mapping[str, object],
+    payload: Mapping[str, object] | None = None,
     todo_service: TodoService | None = None,
 ) -> dict[str, object]:
     try:
@@ -94,7 +110,7 @@ def create_app() -> FastAPI:
 
     app.get("/health")(health)
     app.get("/todos")(app_list_todos)
-    app.post("/todos")(app_create_todo)
+    app.post("/todos", status_code=201)(app_create_todo)
     app.post("/todos/{todo_id}/complete")(app_complete_todo)
     return app
 

--- a/e2e-apps/python-fastapi/tests/test_api_contract.py
+++ b/e2e-apps/python-fastapi/tests/test_api_contract.py
@@ -32,6 +32,16 @@ def _route_endpoint_for(app, path: str, method: str):
     return matches[0]
 
 
+def _route_for(app, path: str, method: str):
+    matches = [
+        route
+        for route in app.routes
+        if getattr(route, "path", None) == path and method in getattr(route, "methods", set())
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
 def test_health_returns_ok_status() -> None:
     assert health() == {"status": "ok"}
 
@@ -45,8 +55,8 @@ def test_create_todo_rejects_blank_titles() -> None:
     assert error.detail == "title_required"
 
 
-def test_create_todo_rejects_non_string_title_payloads() -> None:
-    for payload in ({"title": None}, {"title": 123}):
+def test_create_todo_rejects_non_text_title_payloads() -> None:
+    for payload in (None, {}, {"title": None}, {"title": 123}, {"text": "Ship"}):
         with pytest.raises(HTTPException) as exc_info:
             create_todo(payload)
 
@@ -106,6 +116,13 @@ def test_create_app_keeps_todo_state_isolated_per_app_instance() -> None:
     assert created == {"item": expected_todo}
     assert first_list() == {"todos": [expected_todo]}
     assert second_list()["todos"] == []
+
+
+def test_create_todo_route_uses_created_status_code() -> None:
+    app = create_app()
+    create_route = _route_for(app, "/todos", "POST")
+
+    assert create_route.status_code == 201
 
 
 def test_complete_todo_returns_completed_todo_payload() -> None:


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #499.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `The patch is narrowly scoped to the required FastAPI files, preserves behavior while restoring contract expectations, and fixes the missing coverage by asserting the POST /todos route uses 201. Validation is clean in the configured execution root: `pytest -...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/python-fastapi`
- Targeted tests: `tests/test_api_contract.py`
- Local full gate: `passed`
- Docker full gate: `skipped` (reason `explicit_validation_commands`)

_Built with a little hustle by Flow Healer 🤖✨_
