### PR TITLE
healer: fix issue #635 - Swarm Smoke: Python add rejects bool inputs

### DIFF
--- a/e2e-smoke/python/app/add.py
+++ b/e2e-smoke/python/app/add.py
@@ -3,6 +3,8 @@
 
 def add(left: int, right: int) -> int:
     """Return the arithmetic sum for two integers."""
+    if isinstance(left, bool) or isinstance(right, bool):
+        raise TypeError("add() operands must be integers")
     if type(left) is not int or type(right) is not int:
         raise TypeError("add() operands must be integers")
     return left + right

--- a/e2e-smoke/python/tests/test_add.py
+++ b/e2e-smoke/python/tests/test_add.py
@@ -27,7 +27,9 @@ def test_add_returns_the_sum_of_two_integers() -> None:
     (
         pytest.param(2.5, 3, id="rejects_float_operand"),
         pytest.param("2", 3, id="rejects_string_operand"),
-        pytest.param(True, 3, id="rejects_bool_operand"),
+        pytest.param(True, 3, id="rejects_bool_left_operand"),
+        pytest.param(3, False, id="rejects_bool_right_operand"),
+        pytest.param(True, False, id="rejects_bool_operands"),
     ),
 )
 def test_add_rejects_non_integer_operands(left: object, right: object) -> None:


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #635.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `The patch is narrow and tests pass, but `add()` already rejected booleans because it uses `type(left) is not int or type(right) is not int`. The added `isinstance(..., bool)` guard is redundant and does not materially change runtime behavior, so this does n...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-smoke/python`
- Targeted tests: `tests/test_add.py`
- Local full gate: `passed`
- Docker full gate: `skipped` (reason `explicit_validation_commands`)

_Built with a little hustle by Flow Healer 🤖✨_
