### PR TITLE
healer: fix issue #634 - Swarm Smoke: Node add rejects string operands

### DIFF
--- a/e2e-smoke/node/src/add.js
+++ b/e2e-smoke/node/src/add.js
@@ -8,6 +8,9 @@ const BIGINT_UNSAFE_INTEGER_MESSAGE =
 const VARIADIC_OVERFLOW_UNSAFE_INTEGER_MESSAGE =
   'Cannot mix a variadic bigint-overflow sum with unsafe integer numbers; convert the number input to bigint first.';
 
+const STRING_OPERAND_TYPE_ERROR_MESSAGE =
+  'add() does not accept string operands.';
+
 function isUnsafeIntegerNumber(value) {
   return isIntegerNumber(value) && !Number.isSafeInteger(value);
 }
@@ -48,7 +51,19 @@ function throwVariadicOverflowUnsafeIntegerError() {
   throw new RangeError(VARIADIC_OVERFLOW_UNSAFE_INTEGER_MESSAGE);
 }
 
+function hasStringOperand(a, b) {
+  return typeof a === 'string' || typeof b === 'string';
+}
+
+function throwStringOperandTypeError() {
+  throw new TypeError(STRING_OPERAND_TYPE_ERROR_MESSAGE);
+}
+
 function addPair(a, b) {
+  if (hasStringOperand(a, b)) {
+    throwStringOperandTypeError();
+  }
+
   const canPromoteOperandsToBigInt =
     canConvertToBigInt(a) && canConvertToBigInt(b);
 

--- a/e2e-smoke/node/test/add.test.js
+++ b/e2e-smoke/node/test/add.test.js
@@ -138,6 +138,28 @@ test('add preserves NaN semantics across mixed-number and bigint tails', () => {
   assert.ok(Number.isNaN(leadingNaNResult));
 });
 
+test('add rejects string operands for two-argument calls', () => {
+  assert.throws(() => add('2', 3), {
+    name: 'TypeError',
+    message: 'add() does not accept string operands.',
+  });
+  assert.throws(() => add(2, '3'), {
+    name: 'TypeError',
+    message: 'add() does not accept string operands.',
+  });
+});
+
+test('add rejects string operands for variadic calls', () => {
+  assert.throws(() => add(1, '2', 3), {
+    name: 'TypeError',
+    message: 'add() does not accept string operands.',
+  });
+  assert.throws(() => add(...[1, 2, '3']), {
+    name: 'TypeError',
+    message: 'add() does not accept string operands.',
+  });
+});
+
 test('add keeps a leading undefined input on normal NaN semantics in longer lists', () => {
   assert.ok(Number.isNaN(add(undefined, 1, 2)));
 });


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #634.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch is appropriately narrow to the requested Node smoke files, adds explicit TypeError rejection for string operands in both pairwise and variadic paths via addPair, preserves existing bigint/unsafe-integer behavior for numeric inputs, and the issue-scope...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-smoke/node`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
