### PR TITLE
healer: fix issue #638 - Swarm Smoke: Node add rejects cross-realm boxed strings

### DIFF
--- a/e2e-smoke/node/src/add.js
+++ b/e2e-smoke/node/src/add.js
@@ -51,8 +51,25 @@ function throwVariadicOverflowUnsafeIntegerError() {
   throw new RangeError(VARIADIC_OVERFLOW_UNSAFE_INTEGER_MESSAGE);
 }
 
+function isStringOperand(value) {
+  if (typeof value === 'string') {
+    return true;
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+
+  try {
+    String.prototype.valueOf.call(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function hasStringOperand(a, b) {
-  return typeof a === 'string' || typeof b === 'string';
+  return isStringOperand(a) || isStringOperand(b);
 }
 
 function throwStringOperandTypeError() {

--- a/e2e-smoke/node/test/add.test.js
+++ b/e2e-smoke/node/test/add.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import vm from 'node:vm';
 
 import addDefault, { add } from '../src/add.js';
 
@@ -158,6 +159,43 @@ test('add rejects string operands for variadic calls', () => {
     name: 'TypeError',
     message: 'add() does not accept string operands.',
   });
+});
+
+test('add rejects cross-realm boxed string operands for two-argument calls', () => {
+  const boxedString = vm.runInNewContext('Object("2")');
+
+  assert.throws(() => add(boxedString, 3), {
+    name: 'TypeError',
+    message: 'add() does not accept string operands.',
+  });
+  assert.throws(() => add(2, boxedString), {
+    name: 'TypeError',
+    message: 'add() does not accept string operands.',
+  });
+});
+
+test('add rejects cross-realm boxed string operands for variadic calls', () => {
+  const boxedString = vm.runInNewContext('Object("2")');
+
+  assert.throws(() => add(1, boxedString, 3), {
+    name: 'TypeError',
+    message: 'add() does not accept string operands.',
+  });
+  assert.throws(() => add(...[1, 2, boxedString]), {
+    name: 'TypeError',
+    message: 'add() does not accept string operands.',
+  });
+});
+
+test('add keeps ordinary objects with numeric valueOf on the addition path', () => {
+  const numericObject = {
+    valueOf() {
+      return 2;
+    },
+  };
+
+  assert.equal(add(numericObject, 3), 5);
+  assert.equal(add(1, numericObject, 3), 6);
 });
 
 test('add keeps a leading undefined input on normal NaN semantics in longer lists', () => {


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #638.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch is appropriately scoped to `e2e-smoke/node/src/add.js` and `e2e-smoke/node/test/add.test.js`, adds direct coverage for cross-realm boxed strings in both two-argument and variadic calls, preserves ordinary numeric `valueOf()` objects on the normal addi...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-smoke/node`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
