### PR TITLE
healer: fix issue #646 - Queue Seed 1: Node app regression

### DIFF
--- a/e2e-apps/node-next/lib/todo-service.js
+++ b/e2e-apps/node-next/lib/todo-service.js
@@ -3,6 +3,8 @@ export class TodoService {
     this._todos = todos.map((todo) => ({
       ...todo,
       id: normalizeTodoId(todo?.id),
+      completed: todo?.completed === true,
+      completedAt: todo?.completed === true ? todo?.completedAt ?? null : null,
     }));
     this._nextId = getNextTodoId(this._todos);
   }

--- a/e2e-apps/node-next/tests/todo-service.test.js
+++ b/e2e-apps/node-next/tests/todo-service.test.js
@@ -159,6 +159,31 @@ test("complete can target numeric id 0 values", () => {
   assert.equal(completed?.completed, true);
 });
 
+test("seeded todos normalize legacy completed flags before completing", () => {
+  const service = new TodoService([
+    {
+      id: "4",
+      title: "Legacy seeded todo",
+      completed: "false",
+      createdAt: "2026-03-08T12:00:00.000Z",
+      completedAt: "2026-03-08T12:01:00.000Z",
+    },
+  ]);
+
+  assert.deepEqual(service.list()[0], {
+    id: "4",
+    title: "Legacy seeded todo",
+    completed: false,
+    createdAt: "2026-03-08T12:00:00.000Z",
+    completedAt: null,
+  });
+
+  const completed = service.complete("4");
+
+  assert.equal(completed?.completed, true);
+  assert.ok(completed?.completedAt);
+});
+
 test("list returns a defensive copy to prevent mutation leaks", () => {
   const service = new TodoService();
   service.create("Run canary");


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #646.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch is scoped to the requested Node todo service files, normalizes seeded todos so non-boolean legacy completed flags no longer leak stale completion state, adds a focused regression test for that case, and the required `cd e2e-apps/node-next && npm test...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-apps/node-next`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
