### PR TITLE
healer: fix issue #678 - Queue Seed 17: Nobi Owl Trader sandbox database startup resilience

### DIFF
--- a/e2e-apps/nobi-owl-trader/api/database.py
+++ b/e2e-apps/nobi-owl-trader/api/database.py
@@ -5,6 +5,10 @@ from typing import Optional
 DB_PATH = Path(__file__).parent.parent / "trading_data.db"
 _connection: Optional[sqlite3.Connection] = None
 
+
+class DatabaseInitializationError(RuntimeError):
+    """Raised when the application database cannot be initialized."""
+
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS trades (
     id TEXT PRIMARY KEY,
@@ -155,56 +159,77 @@ def _ensure_columns(conn: sqlite3.Connection, table: str, columns: dict):
             continue
         conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {definition}")
 
+
+def _prepare_db_path(db_path: Optional[str]) -> str:
+    path = db_path if db_path else str(DB_PATH)
+    if path != ":memory:":
+        Path(path).expanduser().resolve().parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
 def init_db(db_path: str = None):
     """Initialize database with schema"""
     global _connection
+    close_db()
     path = db_path if db_path else str(DB_PATH)
-    _connection = sqlite3.connect(path, check_same_thread=False)
-    _connection.row_factory = sqlite3.Row
-    _connection.executescript(SCHEMA)
-    _ensure_columns(
-        _connection,
-        "trades",
-        {
-            "fee_currency": "TEXT",
-            "strategy": "TEXT",
-            "notes": "TEXT",
-            "stop_price": "REAL",
-            "target_price": "REAL",
-            "is_trailing": "BOOLEAN DEFAULT 0",
-            "highest_price": "REAL",
-            "lowest_price": "REAL",
-            "paper": "BOOLEAN DEFAULT 0",
-        },
-    )
-    _ensure_columns(
-        _connection,
-        "automation_rules",
-        {
-            "trigger_type": "TEXT DEFAULT 'signal'",
-            "min_score": "REAL",
-            "amount_type": "TEXT DEFAULT 'fixed'",
-            "stop_loss_pct": "REAL",
-            "take_profit_pct": "REAL",
-            "trailing_stop_pct": "REAL",
-            "only_if_in_position": "BOOLEAN DEFAULT 1",
-            "reduce_only": "BOOLEAN DEFAULT 1",
-            "min_profit_pct": "REAL",
-            "break_even_after_pct": "REAL",
-            "max_hold_bars": "INTEGER",
-            "is_active": "BOOLEAN DEFAULT 1",
-            "last_triggered": "INTEGER DEFAULT 0",
-            "cooldown_minutes": "INTEGER DEFAULT 60",
-            "conditions": "TEXT",
-        },
-    )
-    _connection.execute(
-        "UPDATE automation_rules SET only_if_in_position = 1 WHERE only_if_in_position IS NULL"
-    )
-    _connection.execute(
-        "UPDATE automation_rules SET reduce_only = 1 WHERE reduce_only IS NULL"
-    )
-    _connection.commit()
+
+    try:
+        path = _prepare_db_path(db_path)
+        connection = sqlite3.connect(path, check_same_thread=False)
+        connection.row_factory = sqlite3.Row
+        connection.executescript(SCHEMA)
+        _ensure_columns(
+            connection,
+            "trades",
+            {
+                "fee_currency": "TEXT",
+                "strategy": "TEXT",
+                "notes": "TEXT",
+                "stop_price": "REAL",
+                "target_price": "REAL",
+                "is_trailing": "BOOLEAN DEFAULT 0",
+                "highest_price": "REAL",
+                "lowest_price": "REAL",
+                "paper": "BOOLEAN DEFAULT 0",
+            },
+        )
+        _ensure_columns(
+            connection,
+            "automation_rules",
+            {
+                "trigger_type": "TEXT DEFAULT 'signal'",
+                "min_score": "REAL",
+                "amount_type": "TEXT DEFAULT 'fixed'",
+                "stop_loss_pct": "REAL",
+                "take_profit_pct": "REAL",
+                "trailing_stop_pct": "REAL",
+                "only_if_in_position": "BOOLEAN DEFAULT 1",
+                "reduce_only": "BOOLEAN DEFAULT 1",
+                "min_profit_pct": "REAL",
+                "break_even_after_pct": "REAL",
+                "max_hold_bars": "INTEGER",
+                "is_active": "BOOLEAN DEFAULT 1",
+                "last_triggered": "INTEGER DEFAULT 0",
+                "cooldown_minutes": "INTEGER DEFAULT 60",
+                "conditions": "TEXT",
+            },
+        )
+        connection.execute(
+            "UPDATE automation_rules SET only_if_in_position = 1 WHERE only_if_in_position IS NULL"
+        )
+        connection.execute(
+            "UPDATE automation_rules SET reduce_only = 1 WHERE reduce_only IS NULL"
+        )
+        connection.commit()
+    except (OSError, sqlite3.Error) as exc:
+        if "connection" in locals():
+            connection.close()
+        _connection = None
+        raise DatabaseInitializationError(
+            f"Failed to initialize database at '{path}': {exc}"
+        ) from exc
+
+    _connection = connection
 
 def get_db_connection() -> sqlite3.Connection:
     """Get database connection"""

--- a/e2e-apps/nobi-owl-trader/tests/test_database.py
+++ b/e2e-apps/nobi-owl-trader/tests/test_database.py
@@ -1,5 +1,6 @@
 import pytest
-from api.database import init_db, get_db_connection
+
+from api.database import close_db, get_db_connection, init_db
 
 def test_database_initialization():
     """Test that database creates all required tables"""
@@ -18,4 +19,16 @@ def test_database_initialization():
     assert "portfolio_snapshots" in table_names
     assert "balances" in table_names
 
-    conn.close()
+    close_db()
+
+
+def test_database_initialization_reports_path_on_open_failure(tmp_path):
+    """Test that database startup failures include the target path."""
+    blocked_parent = tmp_path / "occupied"
+    blocked_parent.write_text("not a directory")
+    invalid_path = blocked_parent / "trading_data.db"
+
+    with pytest.raises(RuntimeError, match=str(invalid_path)):
+        init_db(str(invalid_path))
+
+    close_db()


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #678.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch stays scoped to the sandbox database files, adds explicit initialization error handling with path-aware failure messages, closes stale connections before re-init, and the requested validation passes (`cd e2e-apps/nobi-owl-trader && pytest tests/test_d...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/nobi-owl-trader`
- Targeted tests: `tests/test_database.py`
- Local full gate: `passed`
- Docker full gate: `skipped` (reason `explicit_validation_commands`)

_Built with a little hustle by Flow Healer 🤖✨_
