### PR TITLE
healer: fix issue #726 - App expansion 19: Node Next auth session edge coverage

### DIFF
--- a/e2e-apps/node-next/app/api/auth/session/route.js
+++ b/e2e-apps/node-next/app/api/auth/session/route.js
@@ -1,0 +1,76 @@
+function unauthenticatedSession() {
+  return {
+    authenticated: false,
+    session: null,
+  };
+}
+
+export async function GET(request) {
+  const session = readSessionFromRequest(request);
+  if (!session) {
+    return Response.json(unauthenticatedSession(), { status: 200 });
+  }
+
+  return Response.json(
+    {
+      authenticated: true,
+      session,
+    },
+    { status: 200 },
+  );
+}
+
+function readSessionFromRequest(request) {
+  const rawCookieHeader = request?.headers?.get("cookie");
+  if (!rawCookieHeader) {
+    return null;
+  }
+
+  const sessionCookie = rawCookieHeader
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith("session="));
+  if (!sessionCookie) {
+    return null;
+  }
+
+  const rawValue = sessionCookie.slice("session=".length).trim();
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(decodeURIComponent(rawValue));
+    const user = normalizeUser(parsed?.user);
+    const expires = typeof parsed?.expires === "string" ? parsed.expires.trim() : "";
+    if (!user || !expires) {
+      return null;
+    }
+
+    return {
+      user,
+      expires,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function normalizeUser(user) {
+  if (!user || typeof user !== "object") {
+    return null;
+  }
+
+  const normalized = {};
+  if (typeof user.name === "string" && user.name.trim()) {
+    normalized.name = user.name.trim();
+  }
+  if (typeof user.email === "string" && user.email.trim()) {
+    normalized.email = user.email.trim();
+  }
+  if (typeof user.image === "string" && user.image.trim()) {
+    normalized.image = user.image.trim();
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : null;
+}

--- a/e2e-apps/node-next/tests/auth-session-route.test.js
+++ b/e2e-apps/node-next/tests/auth-session-route.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { GET } from "../app/api/auth/session/route.js";
+
+test("GET returns an unauthenticated session payload when the session cookie is missing", async () => {
+  const response = await GET(new Request("http://localhost/api/auth/session"));
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "application/json");
+  assert.deepEqual(await response.json(), {
+    authenticated: false,
+    session: null,
+  });
+});
+
+test("GET returns the normalized session payload from an encoded session cookie", async () => {
+  const response = await GET(
+    new Request("http://localhost/api/auth/session", {
+      headers: {
+        cookie: `session=${encodeURIComponent(
+          JSON.stringify({
+            user: {
+              name: "Taylor",
+              email: "taylor@example.com",
+              image: "https://example.com/avatar.png",
+            },
+            expires: "2026-03-10T12:00:00.000Z",
+          }),
+        )}`,
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    authenticated: true,
+    session: {
+      user: {
+        name: "Taylor",
+        email: "taylor@example.com",
+        image: "https://example.com/avatar.png",
+      },
+      expires: "2026-03-10T12:00:00.000Z",
+    },
+  });
+});
+
+test("GET ignores malformed session cookies instead of throwing", async () => {
+  const response = await GET(
+    new Request("http://localhost/api/auth/session", {
+      headers: {
+        cookie: "session=%E0%A4%A",
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    authenticated: false,
+    session: null,
+  });
+});


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #726.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch stays within the requested auth session route/test scope, adds production behavior for missing, valid, and malformed session cookies, and the issue-scoped validation passed in e2e-apps/node-next with 24/24 tests green. I did not find a broader-scope c...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-apps/node-next`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
