### PR TITLE
healer: fix issue #728 - App expansion 21: Node Next notification digest workflow

### DIFF
--- a/e2e-apps/node-next/lib/notification-digest.js
+++ b/e2e-apps/node-next/lib/notification-digest.js
@@ -1,0 +1,39 @@
+function normalizeMaxItems(maxItems, totalItems) {
+  if (!Number.isFinite(maxItems) || maxItems <= 0) {
+    return totalItems;
+  }
+
+  return Math.min(Math.floor(maxItems), totalItems);
+}
+
+function cloneNotification(notification, sent) {
+  return {
+    ...notification,
+    sent,
+  };
+}
+
+export function flushRecipientDigest(notifications, recipient, options = {}) {
+  const queuedEntries = notifications
+    .map((notification, index) => ({ notification, index }))
+    .filter(
+      ({ notification }) =>
+        notification?.recipient === recipient && notification?.sent !== true,
+    );
+
+  const maxItems = normalizeMaxItems(options.maxItems, queuedEntries.length);
+  const selectedEntries = queuedEntries.slice(0, maxItems);
+  const selectedIndexes = new Set(selectedEntries.map(({ index }) => index));
+
+  return {
+    digest: {
+      recipient,
+      notifications: selectedEntries.map(({ notification }) => notification),
+    },
+    notifications: notifications.map((notification, index) =>
+      selectedIndexes.has(index)
+        ? cloneNotification(notification, true)
+        : cloneNotification(notification, notification?.sent === true),
+    ),
+  };
+}

--- a/e2e-apps/node-next/tests/notification-digest.test.js
+++ b/e2e-apps/node-next/tests/notification-digest.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { flushRecipientDigest } from "../lib/notification-digest.js";
+
+test("flushRecipientDigest leaves another recipient's queued notification untouched when ids collide", () => {
+  const queuedNotifications = [
+    {
+      id: "shared-id",
+      recipient: "alex@example.com",
+      title: "Build finished",
+      message: "The nightly build completed.",
+      createdAt: "2026-03-10T08:00:00.000Z",
+      sent: false,
+    },
+    {
+      id: "shared-id",
+      recipient: "blair@example.com",
+      title: "Build finished",
+      message: "The nightly build completed.",
+      createdAt: "2026-03-10T08:00:00.000Z",
+      sent: false,
+    },
+  ];
+
+  const result = flushRecipientDigest(queuedNotifications, "alex@example.com");
+
+  assert.equal(result.digest.recipient, "alex@example.com");
+  assert.equal(result.digest.notifications.length, 1);
+  assert.equal(result.notifications[0].sent, true);
+  assert.equal(result.notifications[1].sent, false);
+});
+
+test("flushRecipientDigest with maxItems marks only the included notification instances as sent", () => {
+  const queuedNotifications = [
+    {
+      id: "shared-id",
+      recipient: "alex@example.com",
+      title: "Build finished",
+      message: "The nightly build completed.",
+      createdAt: "2026-03-10T08:00:00.000Z",
+      sent: false,
+    },
+    {
+      id: "shared-id",
+      recipient: "alex@example.com",
+      title: "Build finished",
+      message: "The nightly build completed.",
+      createdAt: "2026-03-10T08:00:00.000Z",
+      sent: false,
+    },
+    {
+      id: "shared-id",
+      recipient: "blair@example.com",
+      title: "Build finished",
+      message: "The nightly build completed.",
+      createdAt: "2026-03-10T08:00:00.000Z",
+      sent: false,
+    },
+  ];
+
+  const result = flushRecipientDigest(queuedNotifications, "alex@example.com", {
+    maxItems: 1,
+  });
+
+  assert.equal(result.digest.notifications.length, 1);
+  assert.equal(result.notifications[0].sent, true);
+  assert.equal(result.notifications[1].sent, false);
+  assert.equal(result.notifications[2].sent, false);
+});


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #728.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch stays scoped to the notification digest workflow, fixes the recipient/id collision bug by marking sent notifications via selected array indexes instead of id-only matching, adds the requested regression coverage for cross-recipient collisions and maxI...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-apps/node-next`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
