### PR TITLE
healer: fix issue #729 - App expansion 22: Python FastAPI token refresh service coverage

### DIFF
--- a/e2e-apps/python-fastapi/app/token_service.py
+++ b/e2e-apps/python-fastapi/app/token_service.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+
+@dataclass(slots=True)
+class TokenBundle:
+    access_token: str
+    refresh_token: str
+    expires_at: datetime
+
+
+def refresh_access_token(
+    bundle: TokenBundle,
+    refresh: Callable[[str], Mapping[str, object]],
+    *,
+    now: datetime | None = None,
+    min_ttl_seconds: int = 30,
+) -> TokenBundle:
+    current_time = _normalize_now(now)
+    if _seconds_until_expiry(bundle.expires_at, current_time) > min_ttl_seconds:
+        return TokenBundle(
+            access_token=bundle.access_token,
+            refresh_token=bundle.refresh_token,
+            expires_at=bundle.expires_at,
+        )
+
+    refresh_token = _normalize_text(bundle.refresh_token)
+    if refresh_token is None:
+        raise ValueError("refresh_token_required")
+
+    refreshed = refresh(refresh_token)
+    access_token = _normalize_text(refreshed.get("access_token"))
+    if access_token is None:
+        raise ValueError("access_token_required")
+
+    next_refresh_token = _normalize_text(refreshed.get("refresh_token")) or refresh_token
+    expires_at = _resolve_expiry(refreshed.get("expires_in"), current_time, fallback=bundle.expires_at)
+    return TokenBundle(
+        access_token=access_token,
+        refresh_token=next_refresh_token,
+        expires_at=expires_at,
+    )
+
+
+def _normalize_now(now: datetime | None) -> datetime:
+    if now is None:
+        return datetime.now(UTC)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=UTC)
+    return now
+
+
+def _seconds_until_expiry(expires_at: datetime, now: datetime) -> float:
+    normalized_expiry = expires_at.replace(tzinfo=UTC) if expires_at.tzinfo is None else expires_at
+    return (normalized_expiry - now).total_seconds()
+
+
+def _normalize_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+
+    normalized = value.strip()
+    return normalized or None
+
+
+def _resolve_expiry(raw_expires_in: object, now: datetime, *, fallback: datetime) -> datetime:
+    if raw_expires_in is None:
+        return fallback
+
+    try:
+        expires_in = int(raw_expires_in)
+    except (TypeError, ValueError):
+        return fallback
+
+    if expires_in < 0:
+        return fallback
+    return now + timedelta(seconds=expires_in)

--- a/e2e-apps/python-fastapi/tests/test_token_service.py
+++ b/e2e-apps/python-fastapi/tests/test_token_service.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.token_service import TokenBundle, refresh_access_token
+
+
+def test_refresh_access_token_skips_refresh_when_token_is_still_valid() -> None:
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    bundle = TokenBundle(
+        access_token="current-access",
+        refresh_token="refresh-me",
+        expires_at=now + timedelta(minutes=10),
+    )
+    refresh_calls: list[str] = []
+
+    refreshed = refresh_access_token(
+        bundle,
+        lambda refresh_token: refresh_calls.append(refresh_token) or {},
+        now=now,
+    )
+
+    assert refreshed == bundle
+    assert refreshed is not bundle
+    assert refresh_calls == []
+
+
+def test_refresh_access_token_refreshes_expiring_token_and_preserves_refresh_token() -> None:
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    bundle = TokenBundle(
+        access_token="current-access",
+        refresh_token=" refresh-me ",
+        expires_at=now + timedelta(seconds=20),
+    )
+
+    refreshed = refresh_access_token(
+        bundle,
+        lambda refresh_token: {
+            "access_token": f"{refresh_token}-next",
+            "expires_in": 120,
+        },
+        now=now,
+    )
+
+    assert refreshed.access_token == "refresh-me-next"
+    assert refreshed.refresh_token == "refresh-me"
+    assert refreshed.expires_at == now + timedelta(seconds=120)
+    assert bundle.access_token == "current-access"
+    assert bundle.refresh_token == " refresh-me "
+
+
+def test_refresh_access_token_requires_refresh_token_when_refresh_is_needed() -> None:
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    bundle = TokenBundle(
+        access_token="current-access",
+        refresh_token="   ",
+        expires_at=now + timedelta(seconds=5),
+    )
+
+    with pytest.raises(ValueError, match="refresh_token_required"):
+        refresh_access_token(bundle, lambda _refresh_token: {}, now=now)
+
+
+def test_refresh_access_token_rejects_invalid_refresh_response() -> None:
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    bundle = TokenBundle(
+        access_token="current-access",
+        refresh_token="refresh-me",
+        expires_at=now - timedelta(seconds=1),
+    )
+
+    with pytest.raises(ValueError, match="access_token_required"):
+        refresh_access_token(bundle, lambda _refresh_token: {"expires_in": 60}, now=now)
+
+
+def test_refresh_access_token_uses_existing_expiry_when_provider_omits_lifetime() -> None:
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    original_expiry = now + timedelta(seconds=15)
+    bundle = TokenBundle(
+        access_token="current-access",
+        refresh_token="refresh-me",
+        expires_at=original_expiry,
+    )
+
+    refreshed = refresh_access_token(
+        bundle,
+        lambda _refresh_token: {
+            "access_token": "updated-access",
+            "refresh_token": "",
+        },
+        now=now,
+    )
+
+    assert refreshed.access_token == "updated-access"
+    assert refreshed.refresh_token == "refresh-me"
+    assert refreshed.expires_at == original_expiry


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #729.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Scoped patch only adds the requested FastAPI token service and its tests, and the issue-scoped validation passed (`cd e2e-apps/python-fastapi && python3 -m pytest -q`, 28 passed). The implementation covers refresh skipping, refresh-token validation, access-...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/python-fastapi`
- Targeted tests: `tests/test_token_service.py`
- Local full gate: `passed`
- Docker full gate: `skipped` (reason `explicit_validation_commands`)

_Built with a little hustle by Flow Healer 🤖✨_
