### PR TITLE
healer: fix issue #731 - App expansion 24: Python FastAPI file import workflow coverage

### DIFF
--- a/e2e-apps/python-fastapi/app/importer.py
+++ b/e2e-apps/python-fastapi/app/importer.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+
+from .service import TodoItem, TodoService
+
+
+def import_todos(
+    payload: object,
+    *,
+    todo_service: TodoService | None = None,
+) -> list[TodoItem]:
+    service = TodoService() if todo_service is None else todo_service
+    imported: list[TodoItem] = []
+
+    for entry in _extract_items(payload):
+        created = service.create_todo(_extract_title(entry))
+        if _is_completed(entry):
+            created = service.complete_todo(created.id)
+        imported.append(created)
+
+    return imported
+
+
+def _extract_items(payload: object) -> list[Mapping[str, object]]:
+    resolved = _parse_payload(payload)
+    if isinstance(resolved, Mapping):
+        items = resolved.get("items")
+    elif _is_sequence(resolved):
+        items = resolved
+    else:
+        items = None
+
+    if not _is_sequence(items):
+        raise ValueError("items_payload_required")
+
+    normalized: list[Mapping[str, object]] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            raise ValueError("item_mapping_required")
+        normalized.append(item)
+    return normalized
+
+
+def _parse_payload(payload: object) -> object:
+    if isinstance(payload, str):
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError("items_payload_required") from exc
+    return payload
+
+
+def _extract_title(item: Mapping[str, object]) -> str:
+    title = item.get("title")
+    if not isinstance(title, str):
+        raise ValueError("title_required")
+    return title
+
+
+def _is_completed(item: Mapping[str, object]) -> bool:
+    return item.get("completed") is True
+
+
+def _is_sequence(value: object) -> bool:
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))

--- a/e2e-apps/python-fastapi/tests/test_importer.py
+++ b/e2e-apps/python-fastapi/tests/test_importer.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.importer import import_todos
+from app.service import TodoService
+
+
+def test_import_todos_creates_items_from_json_payload() -> None:
+    service = TodoService()
+
+    imported = import_todos(
+        json.dumps(
+            [
+                {"title": "  Ship release  "},
+                {"title": "Document API", "completed": True},
+            ]
+        ),
+        todo_service=service,
+    )
+
+    assert [item.title for item in imported] == ["Ship release", "Document API"]
+    assert [item.completed for item in imported] == [False, True]
+    assert imported[0].completed_at is None
+    assert imported[1].completed_at is not None
+    assert [item.id for item in service.list_todos()] == ["1", "2"]
+
+
+def test_import_todos_accepts_mapping_with_items_key() -> None:
+    imported = import_todos({"items": [{"title": "Backfill analytics"}]})
+
+    assert len(imported) == 1
+    assert imported[0].title == "Backfill analytics"
+
+
+def test_import_todos_rejects_invalid_payload_shapes() -> None:
+    with pytest.raises(ValueError, match="items_payload_required"):
+        import_todos(None)
+
+    with pytest.raises(ValueError, match="items_payload_required"):
+        import_todos("{")
+
+    with pytest.raises(ValueError, match="items_payload_required"):
+        import_todos({"items": "not-a-list"})
+
+
+def test_import_todos_rejects_invalid_item_entries() -> None:
+    with pytest.raises(ValueError, match="item_mapping_required"):
+        import_todos([None])
+
+    with pytest.raises(ValueError, match="title_required"):
+        import_todos([{"title": "   "}])


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #731.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch is appropriately scoped to the requested FastAPI importer files, implements a production-safe `import_todos` workflow that delegates normalization/completion rules to `TodoService`, and adds focused coverage for JSON payloads, `{items: [...]}` payload...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/python-fastapi`
- Targeted tests: `tests/test_importer.py`
- Local full gate: `passed`
- Docker full gate: `skipped` (reason `explicit_validation_commands`)

_Built with a little hustle by Flow Healer 🤖✨_
