### PR TITLE
healer: fix issue #737 - App expansion 30: Nobi Owl Trader backtest export workflow coverage

### DIFF
--- a/e2e-apps/nobi-owl-trader/api/backtest/exporter.py
+++ b/e2e-apps/nobi-owl-trader/api/backtest/exporter.py
@@ -1,0 +1,77 @@
+import csv
+import io
+from typing import Any, Iterable, Mapping
+
+
+SUMMARY_FIELDS = (
+    "id",
+    "timestamp",
+    "rule_name",
+    "symbol",
+    "timeframe",
+    "initial_balance",
+    "final_balance",
+    "total_trades",
+    "win_rate",
+    "max_drawdown",
+    "max_drawdown_percent",
+    "entry_rule",
+    "exit_rule",
+)
+
+TRADE_FIELDS = (
+    "entry_time",
+    "exit_time",
+    "symbol",
+    "side",
+    "entry_price",
+    "exit_price",
+    "amount",
+    "pnl",
+    "pnl_pct",
+    "reason",
+)
+
+EQUITY_FIELDS = ("timestamp", "equity")
+
+
+def export_backtest_csv(result: Mapping[str, Any]) -> str:
+    buffer = io.StringIO()
+    writer = csv.writer(buffer, lineterminator="\n")
+
+    writer.writerow(("section", "field", "value"))
+    for field in SUMMARY_FIELDS:
+        if field in result and result[field] is not None:
+            writer.writerow(("summary", field, result[field]))
+
+    _write_rows(
+        writer=writer,
+        field_names=TRADE_FIELDS,
+        row_type="trade",
+        rows=result.get("trades", ()),
+    )
+    _write_rows(
+        writer=writer,
+        field_names=EQUITY_FIELDS,
+        row_type="equity",
+        rows=result.get("equity_curve", ()),
+    )
+
+    return buffer.getvalue()
+
+
+def _write_rows(
+    *,
+    writer: Any,
+    field_names: Iterable[str],
+    row_type: str,
+    rows: Iterable[Mapping[str, Any]],
+) -> None:
+    materialized_rows = list(rows)
+    if not materialized_rows:
+        return
+
+    headers = tuple(field_names)
+    writer.writerow(("section", *headers))
+    for row in materialized_rows:
+        writer.writerow((row_type, *(row.get(field, "") for field in headers)))

--- a/e2e-apps/nobi-owl-trader/tests/test_exporter.py
+++ b/e2e-apps/nobi-owl-trader/tests/test_exporter.py
@@ -1,0 +1,61 @@
+from api.backtest.exporter import export_backtest_csv
+
+
+def test_export_backtest_csv_includes_summary_trade_and_equity_sections():
+    result = {
+        "id": "bt-001",
+        "timestamp": 1700000000000,
+        "rule_name": "Momentum Rider",
+        "symbol": "BTC/USDT",
+        "timeframe": "1h",
+        "initial_balance": 10000.0,
+        "final_balance": 11250.5,
+        "total_trades": 2,
+        "win_rate": 50.0,
+        "max_drawdown": 350.25,
+        "max_drawdown_percent": 3.5,
+        "trades": [
+            {
+                "entry_time": 1700000000000,
+                "exit_time": 1700003600000,
+                "symbol": "BTC/USDT",
+                "side": "buy",
+                "entry_price": 40000.0,
+                "exit_price": 40500.0,
+                "amount": 0.1,
+                "pnl": 50.0,
+                "pnl_pct": 1.25,
+                "reason": "Sell Signal",
+            }
+        ],
+        "equity_curve": [
+            {"timestamp": 1700000000000, "equity": 10000.0},
+            {"timestamp": 1700003600000, "equity": 11250.5},
+        ],
+    }
+
+    exported = export_backtest_csv(result)
+
+    assert exported.splitlines()[0] == "section,field,value"
+    assert "summary,rule_name,Momentum Rider" in exported
+    assert "summary,final_balance,11250.5" in exported
+    assert "section,entry_time,exit_time,symbol,side,entry_price,exit_price,amount,pnl,pnl_pct,reason" in exported
+    assert "trade,1700000000000,1700003600000,BTC/USDT,buy,40000.0,40500.0,0.1,50.0,1.25,Sell Signal" in exported
+    assert "section,timestamp,equity" in exported
+    assert "equity,1700003600000,11250.5" in exported
+
+
+def test_export_backtest_csv_skips_empty_trade_and_equity_rows():
+    exported = export_backtest_csv(
+        {
+            "rule_name": "No Trades",
+            "symbol": "ETH/USDT",
+            "trades": [],
+            "equity_curve": [],
+        }
+    )
+
+    assert "summary,rule_name,No Trades" in exported
+    assert "summary,symbol,ETH/USDT" in exported
+    assert "trade," not in exported
+    assert "equity," not in exported


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #737.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Staged patch is publishable: the unified diff is complete for both required files, adds the backtest CSV exporter plus focused coverage for summary/trade/equity sections, and the targeted plus full pytest validation passed in e2e-apps/nobi-owl-trader.`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/nobi-owl-trader`
- Targeted tests: `tests/test_exporter.py`
- Local full gate: `passed`
- Docker full gate: `skipped` (reason `explicit_validation_commands`)

_Built with a little hustle by Flow Healer 🤖✨_
