### PR TITLE
healer: fix issue #803 - Mega final sandbox wave 1 17: Mega final app: Python FastAPI API contract

### DIFF
--- a/e2e-apps/python-fastapi/app/api.py
+++ b/e2e-apps/python-fastapi/app/api.py
@@ -4,9 +4,12 @@ from collections.abc import Mapping
 from .service import TodoItem, TodoService
 
 try:
-    from fastapi import FastAPI, HTTPException
+    from fastapi import Body, FastAPI, HTTPException
 except Exception:  # pragma: no cover - lightweight fallback for minimal environments
     from types import SimpleNamespace
+
+    def Body(default: object = None) -> object:
+        return default
 
     class HTTPException(Exception):
         def __init__(self, *, status_code: int, detail: str) -> None:
@@ -102,7 +105,7 @@ def create_app() -> FastAPI:
     def app_list_todos() -> dict[str, object]:
         return list_todos(app_service)
 
-    def app_create_todo(payload: dict[str, object]) -> dict[str, object]:
+    def app_create_todo(payload: object = Body(default=None)) -> dict[str, object]:
         return create_todo(payload, app_service)
 
     def app_complete_todo(todo_id: str) -> dict[str, object]:

--- a/e2e-apps/python-fastapi/tests/test_api_contract.py
+++ b/e2e-apps/python-fastapi/tests/test_api_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
 
 from app.api import complete_todo, create_app, create_todo, health, list_todos
 
@@ -63,6 +64,16 @@ def test_create_todo_rejects_non_text_title_payloads() -> None:
         error = exc_info.value
         assert error.status_code == 400
         assert error.detail == "title_required"
+
+
+def test_create_todo_route_rejects_missing_and_non_object_bodies_with_contract_error() -> None:
+    client = TestClient(create_app())
+
+    for request_kwargs in ({}, {"json": None}, {"json": []}):
+        response = client.post("/todos", **request_kwargs)
+
+        assert response.status_code == 400
+        assert response.json() == {"detail": "title_required"}
 
 
 def test_list_todos_returns_stable_todos_payload() -> None:


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #803.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch is narrowly scoped to the required FastAPI API contract files, converts the POST /todos route body parameter to use Body(default=None) so missing/null/non-object request bodies reach the app-level title_required handling instead of FastAPI validation,...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/python-fastapi`
- Targeted tests: `tests/test_api_contract.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
