### PR TITLE
fix: resolve node next notification digest baseline

### DIFF
--- a/e2e-apps/node-next/lib/notification-digest.js
+++ b/e2e-apps/node-next/lib/notification-digest.js
@@ -1,42 +1,3 @@
-<<<<<<< HEAD
-function normalizeMaxItems(maxItems, totalItems) {
-  if (!Number.isFinite(maxItems) || maxItems <= 0) {
-    return totalItems;
-  }
-
-  return Math.min(Math.floor(maxItems), totalItems);
-}
-
-function cloneNotification(notification, sent) {
-  return {
-    ...notification,
-    sent,
-  };
-}
-
-export function flushRecipientDigest(notifications, recipient, options = {}) {
-  const queuedEntries = notifications
-    .map((notification, index) => ({ notification, index }))
-    .filter(
-      ({ notification }) =>
-        notification?.recipient === recipient && notification?.sent !== true,
-    );
-
-  const maxItems = normalizeMaxItems(options.maxItems, queuedEntries.length);
-  const selectedEntries = queuedEntries.slice(0, maxItems);
-  const selectedIndexes = new Set(selectedEntries.map(({ index }) => index));
-
-  return {
-    digest: {
-      recipient,
-      notifications: selectedEntries.map(({ notification }) => notification),
-    },
-    notifications: notifications.map((notification, index) =>
-      selectedIndexes.has(index)
-        ? cloneNotification(notification, true)
-        : cloneNotification(notification, notification?.sent === true),
-    ),
-=======
 const QUEUED_STATUS = "queued";
 const SENT_STATUS = "sent";
 
@@ -48,71 +9,103 @@ function normalizeId(value) {
   return String(value ?? "").trim();
 }
 
-function makeRecipientScopedId(recipient, id) {
-  return `${normalizeRecipient(recipient)}\u0000${normalizeId(id)}`;
+function normalizeMaxItems(maxItems, totalItems) {
+  if (!Number.isFinite(maxItems) || maxItems <= 0) {
+    return totalItems;
+  }
+
+  return Math.min(Math.floor(maxItems), totalItems);
 }
 
 function isQueued(notification) {
-  return String(notification?.status ?? QUEUED_STATUS).toLowerCase() === QUEUED_STATUS;
+  if (notification && "status" in notification) {
+    return String(notification.status ?? "").toLowerCase() === QUEUED_STATUS;
+  }
+
+  return notification?.sent !== true;
+}
+
+function toDigestEntry(notification) {
+  return {
+    id: normalizeId(notification?.id),
+    recipient: normalizeRecipient(notification?.recipient),
+    subject: String(notification?.subject ?? notification?.title ?? ""),
+    body: String(notification?.body ?? notification?.message ?? ""),
+    createdAt: String(notification?.createdAt ?? ""),
+  };
+}
+
+function toNotificationSnapshot(notification) {
+  if (notification && "status" in notification) {
+    return {
+      ...notification,
+      sent: String(notification.status ?? "").toLowerCase() === SENT_STATUS,
+    };
+  }
+
+  return {
+    ...notification,
+    sent: notification?.sent === true,
+  };
 }
 
 export function buildRecipientDigest(notifications) {
   const digestByRecipient = new Map();
+
   for (const notification of notifications ?? []) {
     if (!isQueued(notification)) {
       continue;
     }
-    const recipient = normalizeRecipient(notification?.recipient);
-    const id = normalizeId(notification?.id);
-    if (!recipient || !id) {
+
+    const entry = toDigestEntry(notification);
+    if (!entry.recipient || !entry.id) {
       continue;
     }
-    const entry = {
-      id,
-      recipient,
-      subject: String(notification?.subject ?? ""),
-      body: String(notification?.body ?? ""),
-      createdAt: String(notification?.createdAt ?? ""),
-    };
-    const bucket = digestByRecipient.get(recipient) ?? [];
+
+    const bucket = digestByRecipient.get(entry.recipient) ?? [];
     bucket.push(entry);
-    digestByRecipient.set(recipient, bucket);
+    digestByRecipient.set(entry.recipient, bucket);
   }
+
   return Array.from(digestByRecipient.entries())
-    .sort((a, b) => a[0].localeCompare(b[0]))
+    .sort((left, right) => left[0].localeCompare(right[0]))
     .map(([recipient, entries]) => ({ recipient, entries }));
 }
 
 export function flushRecipientDigest(notifications, recipient, options = {}) {
   const recipientKey = normalizeRecipient(recipient);
+  const queuedEntries = (notifications ?? [])
+    .map((notification, index) => ({ notification, index }))
+    .filter(
+      ({ notification }) =>
+        normalizeRecipient(notification?.recipient) === recipientKey && isQueued(notification),
+    );
+
+  const maxItems = normalizeMaxItems(options.maxItems, queuedEntries.length);
+  const selectedEntries = queuedEntries.slice(0, maxItems);
+  const selectedIndexes = new Set(selectedEntries.map(({ index }) => index));
   const sentAt = String(options.sentAt ?? new Date().toISOString());
-  const digest = buildRecipientDigest(notifications).find((item) => item.recipient === recipientKey);
-  if (!recipientKey || !digest) {
-    return { recipient: recipientKey, sent: 0, sentIds: [] };
-  }
 
-  const sentKeys = new Set(
-    digest.entries.map((entry) => makeRecipientScopedId(entry.recipient, entry.id)),
-  );
-
-  let sentCount = 0;
-  for (const notification of notifications ?? []) {
-    if (!isQueued(notification)) {
+  for (const { notification, index } of queuedEntries) {
+    if (!selectedIndexes.has(index)) {
       continue;
     }
-    const key = makeRecipientScopedId(notification?.recipient, notification?.id);
-    if (!sentKeys.has(key)) {
-      continue;
+
+    notification.sent = true;
+    if ("status" in notification) {
+      notification.status = SENT_STATUS;
+      notification.sentAt = sentAt;
     }
-    notification.status = SENT_STATUS;
-    notification.sentAt = sentAt;
-    sentCount += 1;
   }
 
   return {
+    digest: {
+      recipient: recipientKey,
+      notifications: selectedEntries.map(({ notification }) => notification),
+    },
+    notifications: (notifications ?? []).map(toNotificationSnapshot),
     recipient: recipientKey,
-    sent: sentCount,
-    sentIds: digest.entries.map((entry) => entry.id),
->>>>>>> 9bc5021 (fix: harden runtime connectors and normalize prosper chat frontend validation)
+    sent: selectedEntries.length,
+    sentIds: selectedEntries.map(({ notification }) => normalizeId(notification?.id)),
   };
 }

--- a/e2e-apps/node-next/tests/notification-digest.test.js
+++ b/e2e-apps/node-next/tests/notification-digest.test.js
@@ -1,8 +1,67 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-<<<<<<< HEAD
-import { flushRecipientDigest } from "../lib/notification-digest.js";
+import { buildRecipientDigest, flushRecipientDigest } from "../lib/notification-digest.js";
+
+test("buildRecipientDigest groups queued notifications per recipient", () => {
+  const notifications = [
+    { id: "1", recipient: "alice@example.com", subject: "A", status: "queued" },
+    { id: "2", recipient: "alice@example.com", subject: "B", status: "sent" },
+    { id: "3", recipient: "bob@example.com", subject: "C", status: "queued" },
+  ];
+
+  const digest = buildRecipientDigest(notifications);
+
+  assert.deepEqual(digest, [
+    {
+      recipient: "alice@example.com",
+      entries: [
+        {
+          id: "1",
+          recipient: "alice@example.com",
+          subject: "A",
+          body: "",
+          createdAt: "",
+        },
+      ],
+    },
+    {
+      recipient: "bob@example.com",
+      entries: [
+        {
+          id: "3",
+          recipient: "bob@example.com",
+          subject: "C",
+          body: "",
+          createdAt: "",
+        },
+      ],
+    },
+  ]);
+});
+
+test("flushRecipientDigest marks only recipient-scoped ids as sent", () => {
+  const notifications = [
+    { id: "42", recipient: "alice@example.com", subject: "A", status: "queued" },
+    { id: "42", recipient: "bob@example.com", subject: "B", status: "queued" },
+    { id: "43", recipient: "alice@example.com", subject: "C", status: "queued" },
+  ];
+
+  const result = flushRecipientDigest(notifications, "alice@example.com", {
+    sentAt: "2026-03-10T10:20:30Z",
+  });
+
+  assert.equal(result.recipient, "alice@example.com");
+  assert.equal(result.sent, 2);
+  assert.deepEqual(result.sentIds.sort(), ["42", "43"]);
+
+  assert.equal(notifications[0].status, "sent");
+  assert.equal(notifications[0].sentAt, "2026-03-10T10:20:30Z");
+  assert.equal(notifications[1].status, "queued");
+  assert.equal(notifications[1].sentAt, undefined);
+  assert.equal(notifications[2].status, "sent");
+  assert.equal(notifications[2].sentAt, "2026-03-10T10:20:30Z");
+});
 
 test("flushRecipientDigest leaves another recipient's queued notification untouched when ids collide", () => {
   const queuedNotifications = [
@@ -68,64 +127,4 @@ test("flushRecipientDigest with maxItems marks only the included notification in
   assert.equal(result.notifications[0].sent, true);
   assert.equal(result.notifications[1].sent, false);
   assert.equal(result.notifications[2].sent, false);
-=======
-import { buildRecipientDigest, flushRecipientDigest } from "../lib/notification-digest.js";
-
-test("buildRecipientDigest groups queued notifications per recipient", () => {
-  const notifications = [
-    { id: "1", recipient: "alice@example.com", subject: "A", status: "queued" },
-    { id: "2", recipient: "alice@example.com", subject: "B", status: "sent" },
-    { id: "3", recipient: "bob@example.com", subject: "C", status: "queued" },
-  ];
-
-  const digest = buildRecipientDigest(notifications);
-
-  assert.deepEqual(digest, [
-    {
-      recipient: "alice@example.com",
-      entries: [
-        {
-          id: "1",
-          recipient: "alice@example.com",
-          subject: "A",
-          body: "",
-          createdAt: "",
-        },
-      ],
-    },
-    {
-      recipient: "bob@example.com",
-      entries: [
-        {
-          id: "3",
-          recipient: "bob@example.com",
-          subject: "C",
-          body: "",
-          createdAt: "",
-        },
-      ],
-    },
-  ]);
-});
-
-test("flushRecipientDigest marks only recipient-scoped ids as sent", () => {
-  const notifications = [
-    { id: "42", recipient: "alice@example.com", subject: "A", status: "queued" },
-    { id: "42", recipient: "bob@example.com", subject: "B", status: "queued" },
-    { id: "43", recipient: "alice@example.com", subject: "C", status: "queued" },
-  ];
-
-  const result = flushRecipientDigest(notifications, "alice@example.com", { sentAt: "2026-03-10T10:20:30Z" });
-
-  assert.equal(result.recipient, "alice@example.com");
-  assert.equal(result.sent, 2);
-  assert.deepEqual(result.sentIds.sort(), ["42", "43"]);
-
-  assert.equal(notifications[0].status, "sent");
-  assert.equal(notifications[0].sentAt, "2026-03-10T10:20:30Z");
-  assert.equal(notifications[1].status, "queued");
-  assert.equal(notifications[1].sentAt, undefined);
-  assert.equal(notifications[2].status, "sent");
-  assert.equal(notifications[2].sentAt, "2026-03-10T10:20:30Z");
->>>>>>> 9bc5021 (fix: harden runtime connectors and normalize prosper chat frontend validation)
 });


### PR DESCRIPTION
## Summary
- resolve committed merge conflict markers in the Node Next notification digest files
- merge the two partial implementations into one baseline-safe helper
- restore the full Node Next test lane so healer worktrees stop quarantining on unrelated baseline failure

## Verification
- cd e2e-apps/node-next && node --test tests/notification-digest.test.js
- cd e2e-apps/node-next && npm test -- --passWithNoTests
