### PR TITLE
healer: fix issue #804 - Mega final sandbox wave 1 18: Mega final app: Python FastAPI domain service

### DIFF
--- a/e2e-apps/python-fastapi/app/service.py
+++ b/e2e-apps/python-fastapi/app/service.py
@@ -18,6 +18,67 @@ class DomainService:
     def list_services(self) -> list[ServiceRecord]:
         return deepcopy(self._repository.list_services())
 
+    def create_service(
+        self,
+        service_id: str,
+        name: str,
+        *,
+        tags: list[str] | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> ServiceRecord:
+        record = ServiceRecord(
+            service_id=self._require_text(service_id, "service_id_required"),
+            name=self._require_text(name, "name_required"),
+            tags=self._normalize_tags(tags),
+            metadata=deepcopy({} if metadata is None else metadata),
+        )
+        return self._repository.add(record)
+
+    def add_service(
+        self,
+        service_id: str,
+        name: str,
+        *,
+        tags: list[str] | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> ServiceRecord:
+        return self.create_service(service_id, name, tags=tags, metadata=metadata)
+
+    def register_service(
+        self,
+        service_id: str,
+        name: str,
+        *,
+        tags: list[str] | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> ServiceRecord:
+        return self.create_service(service_id, name, tags=tags, metadata=metadata)
+
+    @staticmethod
+    def _normalize_tags(tags: list[str] | None) -> list[str]:
+        if tags is None:
+            return []
+
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for value in tags:
+            tag = DomainService._require_text(value, "tag_required")
+            if tag in seen:
+                continue
+            seen.add(tag)
+            normalized.append(tag)
+        return normalized
+
+    @staticmethod
+    def _require_text(value: str, error_code: str) -> str:
+        if not isinstance(value, str):
+            raise ValueError(error_code)
+
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError(error_code)
+        return normalized
+
 
 @dataclass(slots=True)
 class TodoItem:

--- a/e2e-apps/python-fastapi/tests/test_domain_service.py
+++ b/e2e-apps/python-fastapi/tests/test_domain_service.py
@@ -80,6 +80,50 @@ def test_domain_service_list_services_returns_detached_records() -> None:
     assert repository_services[0].name == "billing"
 
 
+def test_domain_service_create_service_normalizes_and_persists_detached_record() -> None:
+    repository = ServiceRepository()
+    service = DomainService(repository)
+    metadata = {"enabled": False, "retries": 0, "notes": ""}
+
+    created = service.create_service(
+        "  svc-1  ",
+        "  billing  ",
+        tags=[" core ", "core", " jobs "],
+        metadata=metadata,
+    )
+    created.name = "mutated"
+    created.tags.append("mutated")
+    created.metadata["enabled"] = True
+    metadata["retries"] = 5
+
+    stored_services = service.list_services()
+
+    assert stored_services == [
+        ServiceRecord(
+            service_id="svc-1",
+            name="billing",
+            tags=["core", "jobs"],
+            metadata={"enabled": False, "retries": 0, "notes": ""},
+        )
+    ]
+
+
+def test_domain_service_create_service_rejects_invalid_fields() -> None:
+    service = DomainService(ServiceRepository())
+
+    with pytest.raises(ValueError, match="service_id_required"):
+        service.create_service("   ", "billing")
+
+    with pytest.raises(ValueError, match="name_required"):
+        service.create_service("svc-1", "   ")
+
+    with pytest.raises(ValueError, match="tag_required"):
+        service.create_service("svc-1", "billing", tags=["core", "   "])
+
+    with pytest.raises(ValueError, match="service_id_required"):  # type: ignore[arg-type]
+        service.create_service(None, "billing")
+
+
 def test_create_todo_trims_title_and_assigns_incrementing_ids() -> None:
     service = TodoService(repository=InMemoryTodoRepository())
 


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #804.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch is scoped to the requested FastAPI domain service files, adds a small production-safe service creation API with input normalization/validation, and includes focused tests for persistence isolation and invalid-field rejection. Targeted and full issue-s...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/python-fastapi`
- Targeted tests: `tests/test_domain_service.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
