### PR TITLE
healer: fix issue #832 - Mega final sandbox wave 2 15: Mega final app: Python FastAPI repository detach s

### DIFF
--- a/e2e-apps/python-fastapi/app/repository.py
+++ b/e2e-apps/python-fastapi/app/repository.py
@@ -15,7 +15,8 @@ class ServiceRecord:
 
 class ServiceRepository:
     def __init__(self, services: list[ServiceRecord] | None = None) -> None:
-        self._services = [self._clone(service) for service in services or []]
+        source_services = [] if services is None else services
+        self._services = [self._clone(service) for service in source_services]
 
     def add(self, service: ServiceRecord) -> ServiceRecord:
         stored_service = self._clone(service)

--- a/e2e-apps/python-fastapi/tests/test_domain_service.py
+++ b/e2e-apps/python-fastapi/tests/test_domain_service.py
@@ -6,6 +6,11 @@ from app.repository import InMemoryTodoRepository, ServiceRecord, ServiceReposit
 from app.service import DomainService, TodoService
 
 
+class _FalsyServices(list[ServiceRecord]):
+    def __bool__(self) -> bool:
+        return False
+
+
 def test_repository_list_services_returns_detached_records() -> None:
     repository = ServiceRepository(
         [
@@ -28,6 +33,34 @@ def test_repository_list_services_returns_detached_records() -> None:
     assert len(fresh_services) == 1
     assert fresh_services[0].tags == ["core"]
     assert fresh_services[0].metadata == {"region": "us-west-2"}
+
+
+def test_repository_preserves_detached_records_from_explicit_falsy_input() -> None:
+    original_services = _FalsyServices(
+        [
+            ServiceRecord(
+                service_id="svc-1",
+                name="billing",
+                tags=["core"],
+                metadata={"region": "us-west-2"},
+            )
+        ]
+    )
+
+    repository = ServiceRepository(original_services)
+    original_services[0].tags.append("mutated")
+    original_services[0].metadata["region"] = "eu-central-1"
+
+    stored_services = repository.list_services()
+
+    assert stored_services == [
+        ServiceRecord(
+            service_id="svc-1",
+            name="billing",
+            tags=["core"],
+            metadata={"region": "us-west-2"},
+        )
+    ]
 
 
 def test_repository_add_returns_detached_record() -> None:


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #832.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch is appropriately scoped to the repository detach-semantics issue, fixes the explicit falsy-input bug by distinguishing `None` from provided containers, adds a focused regression test, and both targeted and full `pytest -q` validation passed in `e2e-ap...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/python-fastapi`
- Targeted tests: `tests/test_domain_service.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
