### PR TITLE
healer: fix issue #833 - Mega final sandbox wave 2 16: Mega final app: Python FastAPI reporting summary

### DIFF
--- a/e2e-apps/python-fastapi/app/reporting.py
+++ b/e2e-apps/python-fastapi/app/reporting.py
@@ -9,6 +9,7 @@ def generate_report(todo_service: TodoService) -> dict[str, object]:
     todos = [_serialize_todo(item) for item in todo_service.list_todos()]
     total = len(todos)
     completed = sum(1 for item in todos if item["completed"])
+    last_completed_at = _last_completed_at(todos)
 
     return {
         "generated_at": datetime.now(UTC).isoformat(),
@@ -17,6 +18,7 @@ def generate_report(todo_service: TodoService) -> dict[str, object]:
             "completed": completed,
             "pending": total - completed,
             "completion_rate": _completion_rate(total, completed),
+            "last_completed_at": last_completed_at,
         },
         "todos": todos,
     }
@@ -35,3 +37,16 @@ def _completion_rate(total: int, completed: int) -> float:
     if total == 0:
         return 0.0
     return completed / total
+
+
+def _last_completed_at(todos: list[dict[str, object]]) -> str | None:
+    completed_timestamps = [
+        completed_at
+        for item in todos
+        if item["completed"]
+        for completed_at in [item["completed_at"]]
+        if isinstance(completed_at, str) and completed_at.strip()
+    ]
+    if not completed_timestamps:
+        return None
+    return max(completed_timestamps)

--- a/e2e-apps/python-fastapi/tests/test_reporting.py
+++ b/e2e-apps/python-fastapi/tests/test_reporting.py
@@ -17,6 +17,7 @@ def test_generate_report_summarizes_todo_state() -> None:
         "completed": 1,
         "pending": 1,
         "completion_rate": 0.5,
+        "last_completed_at": report["todos"][1]["completed_at"],
     }
     assert report["todos"] == [
         {
@@ -44,6 +45,25 @@ def test_generate_report_handles_empty_state() -> None:
         "completed": 0,
         "pending": 0,
         "completion_rate": 0.0,
+        "last_completed_at": None,
     }
     assert report["todos"] == []
     assert isinstance(report["generated_at"], str)
+
+
+def test_generate_report_uses_latest_completed_timestamp_in_summary() -> None:
+    service = TodoService()
+    first = service.create_todo("Prepare report")
+    second = service.create_todo("Review report")
+
+    completed_first = service.complete_todo(first.id)
+    completed_second = service.complete_todo(second.id)
+
+    report = generate_report(service)
+
+    assert completed_first.completed_at is not None
+    assert completed_second.completed_at is not None
+    assert report["summary"]["last_completed_at"] == max(
+        completed_first.completed_at,
+        completed_second.completed_at,
+    )


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #833.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch is appropriately scoped to reporting summary behavior, adds `summary.last_completed_at` safely from completed todo timestamps, covers empty-state and latest-completion cases in tests, and both targeted `tests/test_reporting.py` and full `pytest -q` va...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/python-fastapi`
- Targeted tests: `tests/test_reporting.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
