### PR TITLE
healer: fix issue #834 - Mega final sandbox wave 2 17: Mega final app: Python FastAPI token refresh flow

### DIFF
--- a/e2e-apps/python-fastapi/app/token_service.py
+++ b/e2e-apps/python-fastapi/app/token_service.py
@@ -37,7 +37,12 @@ def refresh_access_token(
         raise ValueError("access_token_required")
 
     next_refresh_token = _normalize_text(refreshed.get("refresh_token")) or refresh_token
-    expires_at = _resolve_expiry(refreshed.get("expires_in"), current_time, fallback=bundle.expires_at)
+    expires_at = _resolve_expiry(
+        refreshed.get("expires_at"),
+        refreshed.get("expires_in"),
+        current_time,
+        fallback=bundle.expires_at,
+    )
     return TokenBundle(
         access_token=access_token,
         refresh_token=next_refresh_token,
@@ -66,7 +71,18 @@ def _normalize_text(value: object) -> str | None:
     return normalized or None
 
 
-def _resolve_expiry(raw_expires_in: object, now: datetime, *, fallback: datetime) -> datetime:
+def _resolve_expiry(
+    raw_expires_at: object,
+    raw_expires_in: object,
+    now: datetime,
+    *,
+    fallback: datetime,
+) -> datetime:
+    if isinstance(raw_expires_at, datetime):
+        if raw_expires_at.tzinfo is None:
+            return raw_expires_at.replace(tzinfo=UTC)
+        return raw_expires_at
+
     if raw_expires_in is None:
         return fallback
 

--- a/e2e-apps/python-fastapi/tests/test_token_service.py
+++ b/e2e-apps/python-fastapi/tests/test_token_service.py
@@ -96,3 +96,27 @@ def test_refresh_access_token_uses_existing_expiry_when_provider_omits_lifetime(
     assert refreshed.access_token == "updated-access"
     assert refreshed.refresh_token == "refresh-me"
     assert refreshed.expires_at == original_expiry
+
+
+def test_refresh_access_token_uses_provider_expiry_when_available() -> None:
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    original_expiry = now + timedelta(seconds=15)
+    refreshed_expiry = now + timedelta(minutes=5)
+    bundle = TokenBundle(
+        access_token="current-access",
+        refresh_token="refresh-me",
+        expires_at=original_expiry,
+    )
+
+    refreshed = refresh_access_token(
+        bundle,
+        lambda _refresh_token: {
+            "access_token": "updated-access",
+            "expires_at": refreshed_expiry,
+        },
+        now=now,
+    )
+
+    assert refreshed.access_token == "updated-access"
+    assert refreshed.refresh_token == "refresh-me"
+    assert refreshed.expires_at == refreshed_expiry


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #834.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Scoped patch only updates the requested FastAPI token refresh files, teaches `refresh_access_token` to prefer provider-supplied `expires_at` datetimes before falling back to `expires_in` or the prior expiry, and adds targeted coverage for that flow. Targete...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/python-fastapi`
- Targeted tests: `tests/test_token_service.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
