### PR TITLE
healer: fix issue #864 - Prod eval hybrid-heavy 5: Hybrid: Django add helper regressed on numeric strings

### DIFF
--- a/e2e-smoke/py-django/app/add.py
+++ b/e2e-smoke/py-django/app/add.py
@@ -3,7 +3,7 @@ def _coerce_int(value: object) -> int:
         raise TypeError("boolean operands are not allowed")
     try:
         return int(value)
-    except TypeError:
+    except (TypeError, ValueError):
         return int(str(value))
 
 

--- a/e2e-smoke/py-django/tests/test_add.py
+++ b/e2e-smoke/py-django/tests/test_add.py
@@ -18,6 +18,20 @@ def test_add_accepts_stringable_values() -> None:
     assert add(DjangoStringable("2"), DjangoStringable("3")) == 5
 
 
+def test_add_accepts_numeric_string_wrappers_with_broken_int_conversion() -> None:
+    class DjangoBoundaryValue:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+        def __int__(self) -> int:
+            raise ValueError("boundary coercion failed")
+
+        def __str__(self) -> str:
+            return self.value
+
+    assert add(DjangoBoundaryValue("2"), DjangoBoundaryValue("3")) == 5
+
+
 def test_add_rejects_boolean_operands() -> None:
     with pytest.raises(TypeError):
         add(True, 2)


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #864.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch is appropriately scoped and production-safe. It restores numeric-string compatibility in `e2e-smoke/py-django/app/add.py` by falling back to `str()` coercion when `__int__` raises `ValueError`, and the added test in `e2e-smoke/py-django/tests/test_add...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-smoke/py-django`
- Targeted tests: `tests/test_add.py`
- Local full gate: `passed`
- Docker full gate: `skipped` (reason `explicit_validation_commands`)

_Built with a little hustle by Flow Healer 🤖✨_
