### PR TITLE
healer: fix issue #865 - Prod eval hybrid-heavy 6: Hybrid: FastAPI health response lost service metadata

### DIFF
--- a/e2e-apps/python-fastapi/app/api.py
+++ b/e2e-apps/python-fastapi/app/api.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections.abc import Mapping
 from .service import TodoItem, TodoService
 
+APP_NAME = "Flow Healer Python FastAPI Sandbox"
+
 try:
     from fastapi import Body, FastAPI, HTTPException
 except Exception:  # pragma: no cover - lightweight fallback for minimal environments
@@ -47,8 +49,8 @@ except Exception:  # pragma: no cover - lightweight fallback for minimal environ
 service = TodoService()
 
 
-def health() -> dict[str, str]:
-    return {"status": "ok"}
+def health() -> dict[str, object]:
+    return {"status": "ok", "service": {"name": APP_NAME}}
 
 
 def _service_for(request_service: TodoService | None) -> TodoService:
@@ -99,7 +101,7 @@ def complete_todo(todo_id: str, todo_service: TodoService | None = None) -> dict
 
 
 def create_app() -> FastAPI:
-    app = FastAPI(title="Flow Healer Python FastAPI Sandbox")
+    app = FastAPI(title=APP_NAME)
     app_service = TodoService()
 
     def app_list_todos() -> dict[str, object]:

--- a/e2e-apps/python-fastapi/tests/test_api_contract.py
+++ b/e2e-apps/python-fastapi/tests/test_api_contract.py
@@ -7,6 +7,8 @@ from fastapi.testclient import TestClient
 
 from app.api import complete_todo, create_app, create_todo, health, list_todos
 
+APP_NAME = "Flow Healer Python FastAPI Sandbox"
+
 
 def _expected_todo_payload(
     *,
@@ -44,7 +46,16 @@ def _route_for(app, path: str, method: str):
 
 
 def test_health_returns_ok_status() -> None:
-    assert health() == {"status": "ok"}
+    assert health() == {"status": "ok", "service": {"name": APP_NAME}}
+
+
+def test_health_route_returns_service_metadata_contract() -> None:
+    client = TestClient(create_app())
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "service": {"name": APP_NAME}}
 
 
 def test_create_todo_rejects_blank_titles() -> None:


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #865.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Restores the FastAPI health response contract by returning the expected service metadata (`service.name`) from `app/api.py`, keeps the app title consistent via a shared constant, and adds direct contract coverage for both the helper and `/health` route. The...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/python-fastapi`
- Targeted tests: `tests/test_api_contract.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
