### PR TITLE
healer: fix issue #868 - Prod eval hybrid-heavy 9: Messy: pandas helper fix should stay pandas-specific

### DIFF
--- a/e2e-smoke/py-data-pandas/app/add.py
+++ b/e2e-smoke/py-data-pandas/app/add.py
@@ -3,6 +3,6 @@ from typing import Any
 
 
 def add(a: Any, b: Any) -> Any:
-    if isinstance(a, (pd.Series, pd.DataFrame)):
+    if isinstance(a, pd.core.base.PandasObject) and callable(getattr(a, "add", None)):
         return a.add(b)
     return a + b

--- a/e2e-smoke/py-data-pandas/tests/test_add.py
+++ b/e2e-smoke/py-data-pandas/tests/test_add.py
@@ -60,3 +60,24 @@ def test_add_uses_pandas_native_add_when_available() -> None:
     expected = pd.DataFrame({"value": [11, 12, 13]})
     pd.testing.assert_frame_equal(result, expected, check_frame_type=False)
     assert result.used_native_add is True
+
+
+def test_add_uses_native_add_for_pandas_objects_only() -> None:
+    class TrackingPandasObject(pd.core.base.PandasObject):
+        def __init__(self, value: int) -> None:
+            self.value = value
+            self.used_native_add = False
+
+        def __add__(self, other: int) -> "TrackingPandasObject":
+            return TrackingPandasObject(self.value + other)
+
+        def add(self, other: int) -> "TrackingPandasObject":
+            self.used_native_add = True
+            result = TrackingPandasObject(self.value + other + 100)
+            result.used_native_add = True
+            return result
+
+    result = add(TrackingPandasObject(1), 2)
+
+    assert result.value == 103
+    assert result.used_native_add is True


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #868.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch stays narrowly scoped to the pandas smoke helper, keeps behavior pandas-specific by requiring a pandas base object plus native add support, adds a focused regression test for that contract, and the targeted/full pytest validation both passed.`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-smoke/py-data-pandas`
- Targeted tests: `tests/test_add.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
