### PR TITLE
healer: fix issue #927 - Phase 2 eval: Node Next auth session normalization

### DIFF
--- a/e2e-apps/node-next/app/api/auth/session/route.js
+++ b/e2e-apps/node-next/app/api/auth/session/route.js
@@ -34,7 +34,7 @@ function readSessionFromRequest(request) {
     return null;
   }
 
-  const rawValue = sessionCookie.slice("session=".length).trim();
+  const rawValue = normalizeCookieValue(sessionCookie.slice("session=".length));
   if (!rawValue) {
     return null;
   }
@@ -54,6 +54,21 @@ function readSessionFromRequest(request) {
   } catch {
     return null;
   }
+}
+
+function normalizeCookieValue(value) {
+  const trimmedValue = typeof value === "string" ? value.trim() : "";
+  if (!trimmedValue) {
+    return "";
+  }
+
+  const hasWrappingQuotes =
+    trimmedValue.startsWith('"') && trimmedValue.endsWith('"') && trimmedValue.length >= 2;
+  if (!hasWrappingQuotes) {
+    return trimmedValue;
+  }
+
+  return trimmedValue.slice(1, -1).trim();
 }
 
 function normalizeUser(user) {

--- a/e2e-apps/node-next/tests/auth-session-route.test.js
+++ b/e2e-apps/node-next/tests/auth-session-route.test.js
@@ -61,3 +61,33 @@ test("GET ignores malformed session cookies instead of throwing", async () => {
     session: null,
   });
 });
+
+test("GET normalizes quoted session cookies before parsing the session payload", async () => {
+  const response = await GET(
+    new Request("http://localhost/api/auth/session", {
+      headers: {
+        cookie: `session="${encodeURIComponent(
+          JSON.stringify({
+            user: {
+              name: "  Taylor  ",
+              email: "  taylor@example.com  ",
+            },
+            expires: " 2026-03-10T12:00:00.000Z ",
+          }),
+        )}"`,
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    authenticated: true,
+    session: {
+      user: {
+        name: "Taylor",
+        email: "taylor@example.com",
+      },
+      expires: "2026-03-10T12:00:00.000Z",
+    },
+  });
+});


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #927.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Scoped change stays within the requested auth session route and test files, adds focused coverage for quoted session cookies, and preserves passing issue-scoped validation (`cd e2e-apps/node-next && npm test -- --passWithNoTests`). The staged patch is small...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-apps/node-next`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
