### PR TITLE
healer: fix issue #953 - Node Next homepage: add screenshot-proof evidence marker

### DIFF
--- a/e2e-apps/node-next/app/page.js
+++ b/e2e-apps/node-next/app/page.js
@@ -2,6 +2,7 @@ export default function HomePage() {
   return (
     <section aria-labelledby="todo-routes-heading">
       <p>Browser smoke ready</p>
+      <p>Evidence TC 1</p>
       <h2 id="todo-routes-heading">Available todo routes</h2>
       <ul>
         <li>GET /api/todos</li>


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #953.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Minimal homepage-only change in e2e-apps/node-next/app/page.js adds the browser-visible marker `Evidence TC 1` while preserving `Browser smoke ready`. The staged scope matches the issue, and `cd e2e-apps/node-next && npm test` passed.`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-apps/node-next`
- Local full gate: `passed`
- Docker full gate: `skipped` (reason `explicit_validation_commands`)

_Built with a little hustle by Flow Healer 🤖✨_
