### PR TITLE
healer: fix issue #983 - Python smoke: add_many helper

### DIFF
--- a/e2e-smoke/python/app/add.py
+++ b/e2e-smoke/python/app/add.py
@@ -20,3 +20,8 @@ def _coerce_int(value: int | str) -> int:
 def add(left: int | str, right: int | str) -> int:
     """Return the arithmetic sum for integer-like inputs, rejecting invalid inputs."""
     return _coerce_int(left) + _coerce_int(right)
+
+
+def add_many(first: int | str, second: int | str, third: int | str) -> int:
+    """Return the arithmetic sum for three integer-like inputs."""
+    return _coerce_int(first) + _coerce_int(second) + _coerce_int(third)

--- a/e2e-smoke/python/tests/test_add.py
+++ b/e2e-smoke/python/tests/test_add.py
@@ -34,6 +34,25 @@ def test_add_accepts_stringified_integer_operands() -> None:
     assert module.add("2", "3") == 5
 
 
+def test_add_many_returns_the_sum_of_three_integers() -> None:
+    module = _load_add_module()
+
+    assert module.add_many(2, 3, 4) == 9
+
+
+def test_add_many_accepts_stringified_integer_operands() -> None:
+    module = _load_add_module()
+
+    assert module.add_many("2", "3", "4") == 9
+
+
+def test_add_many_rejects_invalid_operands() -> None:
+    module = _load_add_module()
+
+    with pytest.raises(TypeError, match=r"^add\(\) operands must be integers$"):
+        module.add_many("two", 3, 4)
+
+
 @pytest.mark.parametrize(
     ("left", "right"),
     (


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #983.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch is narrowly scoped to the requested Python smoke fixture files, adds add_many(first, second, third) using the same _coerce_int-based coercion behavior as add, covers integers, integer strings, and an invalid operand case, and the targeted plus full py...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-smoke/python`
- Targeted tests: `tests/test_add.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
