### PR TITLE
healer: fix issue #984 - FastAPI smoke: add_many helper

### DIFF
--- a/e2e-smoke/py-fastapi/app/add.py
+++ b/e2e-smoke/py-fastapi/app/add.py
@@ -4,6 +4,12 @@ def add(a: int | str, b: int | str) -> int:
     return _coerce_int(a) + _coerce_int(b)
 
 
+def add_many(first: int | str, second: int | str, third: int | str) -> int:
+    """Return an integer sum for three FastAPI-style numeric inputs."""
+
+    return _coerce_int(first) + _coerce_int(second) + _coerce_int(third)
+
+
 def _coerce_int(value: int | str) -> int:
     if isinstance(value, bool):
         raise TypeError("boolean operands are not allowed")

--- a/e2e-smoke/py-fastapi/tests/test_add.py
+++ b/e2e-smoke/py-fastapi/tests/test_add.py
@@ -4,7 +4,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from app.add import add
+from app.add import add, add_many
 
 
 def test_add() -> None:
@@ -17,6 +17,19 @@ def test_add_coerces_fastapi_string_inputs() -> None:
 
 def test_add_accepts_whitespace_padded_integer_strings() -> None:
     assert add(" 2 ", "\n3\t") == 5
+
+
+def test_add_many_coerces_integer_strings() -> None:
+    assert add_many("2", "3", "4") == 9
+
+
+def test_add_many_accepts_whitespace_padded_integer_strings() -> None:
+    assert add_many(" 2 ", "\n3\t", " 4\n") == 9
+
+
+def test_add_many_rejects_blank_string_operands() -> None:
+    with pytest.raises(TypeError, match="blank string operands are not allowed"):
+        add_many("2", " ", "4")
 
 
 @pytest.mark.parametrize("a, b", [("", "3"), ("2", " "), ("\t", "\n")])


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #984.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Scoped change matches the issue: added `add_many(first, second, third)` in `e2e-smoke/py-fastapi/app/add.py`, reused existing `_coerce_int` behavior to preserve string coercion and blank-string rejection, and added the requested tests for integer strings, w...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-smoke/py-fastapi`
- Targeted tests: `tests/test_add.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
