### PR TITLE
healer: fix issue #985 - Flask smoke: add_many helper

### DIFF
--- a/e2e-smoke/py-flask/app/add.py
+++ b/e2e-smoke/py-flask/app/add.py
@@ -2,6 +2,10 @@ def add(a: int | str, b: int | str) -> int:
     return _coerce_int(a) + _coerce_int(b)
 
 
+def add_many(first: int | str, second: int | str, third: int | str) -> int:
+    return _coerce_int(first) + _coerce_int(second) + _coerce_int(third)
+
+
 def _coerce_int(value: int | str) -> int:
     if isinstance(value, bool):
         raise TypeError("boolean operands are not allowed")

--- a/e2e-smoke/py-flask/tests/test_add.py
+++ b/e2e-smoke/py-flask/tests/test_add.py
@@ -5,7 +5,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from app.add import add
+from app.add import add, add_many
 
 
 def test_add() -> None:
@@ -20,3 +20,12 @@ def test_add_coerces_flask_string_inputs() -> None:
 def test_add_rejects_boolean_operands(a: int | bool, b: int | bool) -> None:
     with pytest.raises(TypeError, match="boolean operands are not allowed"):
         add(a, b)
+
+
+def test_add_many_coerces_flask_string_inputs() -> None:
+    assert add_many("2", "3", "4") == 9
+
+
+def test_add_many_rejects_boolean_operands() -> None:
+    with pytest.raises(TypeError, match="boolean operands are not allowed"):
+        add_many(2, True, 4)


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #985.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Adds `add_many(first, second, third)` in the Flask smoke fixture using the existing `_coerce_int` helper, preserving string coercion and boolean rejection behavior. Test coverage was updated in the scoped Flask fixture to verify string inputs and a boolean...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-smoke/py-flask`
- Targeted tests: `tests/test_add.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
