### PR TITLE
healer: fix issue #986 - Pandas smoke: add_many helper

### DIFF
--- a/e2e-smoke/py-data-pandas/app/add.py
+++ b/e2e-smoke/py-data-pandas/app/add.py
@@ -6,3 +6,7 @@ def add(a: Any, b: Any) -> Any:
     if isinstance(a, pd.core.base.PandasObject) and callable(getattr(a, "add", None)):
         return a.add(b)
     return a + b
+
+
+def add_many(first: Any, second: Any, third: Any) -> Any:
+    return add(add(first, second), third)

--- a/e2e-smoke/py-data-pandas/tests/test_add.py
+++ b/e2e-smoke/py-data-pandas/tests/test_add.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from app.add import add
+from app.add import add, add_many
 
 
 def test_add() -> None:
@@ -81,3 +81,16 @@ def test_add_uses_native_add_for_pandas_objects_only() -> None:
 
     assert result.value == 103
     assert result.used_native_add is True
+
+
+def test_add_many_with_scalars() -> None:
+    assert add_many(2, 3, 4) == 9
+
+
+def test_add_many_preserves_pandas_dataframe_behavior() -> None:
+    values = pd.DataFrame({"value": [1, 2, 3]})
+
+    result = add_many(values, 10, 100)
+
+    expected = pd.DataFrame({"value": [111, 112, 113]})
+    pd.testing.assert_frame_equal(result, expected)


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #986.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch is correctly scoped to the two requested files, adds add_many(first, second, third) by composing the existing add helper so pandas-native add behavior is preserved when the first operand is a pandas object, and includes both scalar and pandas DataFram...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-smoke/py-data-pandas`
- Targeted tests: `tests/test_add.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
