### PR TITLE
healer: fix issue #988 - Rust smoke: sum_slice helper

### DIFF
--- a/e2e-smoke/rust/src/lib.rs
+++ b/e2e-smoke/rust/src/lib.rs
@@ -5,3 +5,7 @@ pub fn add(left: i32, right: i32) -> i32 {
 pub fn add_many(left: i32, right: i32, extra: i32) -> i32 {
     left + right + extra
 }
+
+pub fn sum_slice(values: &[i32]) -> i32 {
+    values.iter().sum()
+}

--- a/e2e-smoke/rust/tests/add.rs
+++ b/e2e-smoke/rust/tests/add.rs
@@ -1,4 +1,4 @@
-use flow_healer_rust_smoke::{add, add_many};
+use flow_healer_rust_smoke::{add, add_many, sum_slice};
 
 #[test]
 fn adds_two_numbers() {
@@ -8,4 +8,19 @@ fn adds_two_numbers() {
 #[test]
 fn adds_three_numbers() {
     assert_eq!(add_many(2, 3, 4), 9);
+}
+
+#[test]
+fn sums_an_empty_slice() {
+    assert_eq!(sum_slice(&[]), 0);
+}
+
+#[test]
+fn sums_a_positive_slice() {
+    assert_eq!(sum_slice(&[1, 2, 3, 4]), 10);
+}
+
+#[test]
+fn sums_a_mixed_sign_slice() {
+    assert_eq!(sum_slice(&[-5, 10, -2, 4]), 7);
 }


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #988.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch is correctly scoped to the requested Rust smoke fixture files, adds the public `sum_slice(values: &[i32]) -> i32` helper without changing `add` or `add_many`, includes the required empty/positive/mixed-sign tests, and `cd e2e-smoke/rust && cargo test`...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `rust`
- Execution root: `e2e-smoke/rust`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
