### PR TITLE
healer: fix issue #1028 - GPT-5.1 Codex Mini sandbox 11: Mega final smoke: Django utility behavior

### DIFF
--- a/e2e-smoke/py-django/app/add.py
+++ b/e2e-smoke/py-django/app/add.py
@@ -1,6 +1,10 @@
 def _coerce_int(value: object) -> int:
     if isinstance(value, bool):
         raise TypeError("boolean operands are not allowed")
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            raise TypeError("blank string operands are not allowed")
     try:
         return int(value)
     except (TypeError, ValueError):

--- a/e2e-smoke/py-django/tests/test_add.py
+++ b/e2e-smoke/py-django/tests/test_add.py
@@ -32,6 +32,16 @@ def test_add_accepts_numeric_string_wrappers_with_broken_int_conversion() -> Non
     assert add(DjangoBoundaryValue("2"), DjangoBoundaryValue("3")) == 5
 
 
+def test_add_accepts_whitespace_padded_integer_strings() -> None:
+    assert add(" 2 ", "\n3\t") == 5
+
+
+@pytest.mark.parametrize("a, b", [("", "3"), ("2", " "), ("\t", "\n")])
+def test_add_rejects_blank_string_operands(a: str, b: str) -> None:
+    with pytest.raises(TypeError, match="blank string operands are not allowed"):
+        add(a, b)
+
+
 def test_add_rejects_boolean_operands() -> None:
     with pytest.raises(TypeError):
         add(True, 2)


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1028.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch is within allowed scope (`e2e-smoke/py-django/app/add.py` and `e2e-smoke/py-django/tests/test_add.py` only), adds explicit whitespace trimming/blank-string rejection for string operands in `_coerce_int`, and preserves existing numeric coercion behavio...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-smoke/py-django`
- Targeted tests: `tests/test_add.py`
- Local full gate: `passed`
- Docker full gate: `skipped` (reason `explicit_validation_commands`)

_Built with a little hustle by Flow Healer 🤖✨_
