### PR TITLE
healer: fix issue #1031 - GPT-5.1 Codex Mini sandbox 14: Mega final app: Node Next todo route and service 

### DIFF
--- a/e2e-apps/node-next/app/api/todos/route.js
+++ b/e2e-apps/node-next/app/api/todos/route.js
@@ -1,5 +1,4 @@
 import {
-  normalizeTodoTitle,
   toTodoItemPayload,
   toTodoListPayload,
   todoService,
@@ -25,9 +24,12 @@ export async function POST(request) {
   }
 
   try {
-    const created = todoService.create(normalizeTodoTitle(payload.title));
+    const created = todoService.create(payload.title);
     return Response.json(toTodoItemPayload(created), { status: 201 });
   } catch (error) {
-    return Response.json({ error: String(error.message || "create_failed") }, { status: 400 });
+    return Response.json(
+      { error: String(error?.message) === "title_required" ? "title_required" : "create_failed" },
+      { status: 400 },
+    );
   }
 }

--- a/e2e-apps/node-next/lib/todo-service.js
+++ b/e2e-apps/node-next/lib/todo-service.js
@@ -104,7 +104,7 @@ function normalizeCompletedFlag(value) {
 
 export function toPublicTodo(todo) {
   return {
-    id: Number(todo.id),
+    id: Number(normalizeTodoId(todo?.id)),
     title: todo.title,
     completed: todo.completed,
   };

--- a/e2e-apps/node-next/tests/todo-service.test.js
+++ b/e2e-apps/node-next/tests/todo-service.test.js
@@ -7,6 +7,7 @@ import {
   TodoService,
   toPublicTodo,
   toPublicTodoList,
+  todoService,
   toTodoItemPayload,
   toTodoListPayload,
 } from "../lib/todo-service.js";
@@ -256,6 +257,17 @@ test("toPublicTodo strips internal fields and normalizes the id type", () => {
   );
 });
 
+test("toPublicTodo normalizes public ids before exposing them", () => {
+  assert.equal(
+    toPublicTodo({
+      id: " +09 ",
+      title: "Legacy spacing",
+      completed: false,
+    }).id,
+    9,
+  );
+});
+
 test("todo payload helpers keep the collection and item route shape stable", () => {
   const todos = [
     {
@@ -314,6 +326,28 @@ test("POST rejects blank and malformed titles", async () => {
   assert.equal(malformedResponse.status, 400);
   assert.deepEqual(await malformedResponse.json(), { error: "title_required" });
   assert.equal(listTodos().length, todosBefore);
+});
+
+test("POST returns create_failed for unexpected create errors", async () => {
+  const originalCreate = todoService.create;
+  todoService.create = () => {
+    throw new Error("service_down");
+  };
+
+  try {
+    const response = await POST(
+      new Request("http://localhost/api/todos", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "Will not persist" }),
+      }),
+    );
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), { error: "create_failed" });
+  } finally {
+    todoService.create = originalCreate;
+  }
 });
 
 test("POST returns the same stable public todo fields as GET", async () => {


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1031.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `The proposed patch is constrained to the required output targets (route, service, tests), preserves route/service contract expectations, and addresses the intended behavior changes: route now delegates title handling to service validation and maps non-title...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-apps/node-next`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
