### PR TITLE
healer: fix issue #1032 - GPT-5.1 Codex Mini sandbox 17: Mega final app: Python FastAPI API contract

### DIFF
--- a/e2e-apps/python-fastapi/app/api.py
+++ b/e2e-apps/python-fastapi/app/api.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import Final
 from .service import TodoItem, TodoService
 
 APP_NAME = "Flow Healer Python FastAPI Sandbox"
+HEALTH_SERVICE_NAME: Final[str] = APP_NAME
 
 try:
     from fastapi import Body, FastAPI, HTTPException
@@ -50,7 +52,7 @@ service = TodoService()
 
 
 def health() -> dict[str, object]:
-    return {"status": "ok", "service": {"name": APP_NAME}}
+    return {"status": "ok", "service": {"name": HEALTH_SERVICE_NAME}}
 
 
 def _service_for(request_service: TodoService | None) -> TodoService:

--- a/e2e-apps/python-fastapi/tests/test_api_contract.py
+++ b/e2e-apps/python-fastapi/tests/test_api_contract.py
@@ -25,6 +25,10 @@ def _expected_todo_payload(
     }
 
 
+def _expected_health_payload() -> dict[str, object]:
+    return {"status": "ok", "service": {"name": APP_NAME}}
+
+
 def _route_endpoint_for(app, path: str, method: str):
     matches = [
         route.endpoint
@@ -55,7 +59,13 @@ def test_health_route_returns_service_metadata_contract() -> None:
     response = client.get("/health")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "ok", "service": {"name": APP_NAME}}
+    assert response.json() == _expected_health_payload()
+
+
+def test_health_payload_returns_fresh_contract_copy() -> None:
+    response_one = health()
+    response_one["service"]["name"] = "tampered-name"
+    assert health() == _expected_health_payload()
 
 
 def test_create_todo_rejects_blank_titles() -> None:


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1032.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Validation passes in the target execution root (`pytest -q` full suite = 43 passed), and changes are scoped to the required files: `e2e-apps/python-fastapi/app/api.py` and `e2e-apps/python-fastapi/tests/test_api_contract.py`. The patch preserves existing he...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/python-fastapi`
- Targeted tests: `tests/test_api_contract.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
