### PR TITLE
healer: fix issue #1037 - GPT-5.1 Codex Mini sandbox 2: Mega final smoke: Nuxt server helper behavior

### DIFF
--- a/e2e-smoke/js-nuxt/src/add.js
+++ b/e2e-smoke/js-nuxt/src/add.js
@@ -6,7 +6,7 @@ function add(a, b) {
 }
 
 function toFiniteNumber(value) {
-  if (value && typeof value === 'object' && 'value' in value) {
+  while (value && typeof value === 'object' && 'value' in value) {
     value = value.value;
   }
 
@@ -17,16 +17,18 @@ function toFiniteNumber(value) {
       throw new TypeError('add expects finite numeric inputs');
     }
 
-    value = trimmed;
+    value = Number(trimmed);
   }
 
-  const number = Number(value);
-
-  if (!Number.isFinite(number)) {
+  if (typeof value !== 'number') {
     throw new TypeError('add expects finite numeric inputs');
   }
 
-  return number;
+  if (!Number.isFinite(value)) {
+    throw new TypeError('add expects finite numeric inputs');
+  }
+
+  return value;
 }
 
 module.exports = { add };

--- a/e2e-smoke/js-nuxt/tests/add.test.js
+++ b/e2e-smoke/js-nuxt/tests/add.test.js
@@ -4,7 +4,16 @@ const { add } = require('../src/add');
 assert.strictEqual(add(1, 2), 3);
 assert.strictEqual(add('2', '5'), 7);
 assert.strictEqual(add({ value: '4' }, 3), 7);
+assert.strictEqual(add({ value: { value: '  8 ' } }, 2), 10);
 assert.throws(() => add('', 5), {
+  name: 'TypeError',
+  message: 'add expects finite numeric inputs',
+});
+assert.throws(() => add(true, 5), {
+  name: 'TypeError',
+  message: 'add expects finite numeric inputs',
+});
+assert.throws(() => add(null, 5), {
   name: 'TypeError',
   message: 'add expects finite numeric inputs',
 });


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1037.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `The patch is in-scope (only `e2e-smoke/js-nuxt/src/add.js` and `e2e-smoke/js-nuxt/tests/add.test.js` changed) and preserves the intended behavior while tightening input validation: it now unwraps nested `{ value: ... }` objects recursively, requires numeric...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-smoke/js-nuxt`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
