### PR TITLE
healer: fix issue #1110 - Hard batch 4: Hard app: Node Next notification digest stability

### DIFF
--- a/e2e-apps/node-next/lib/notification-digest.js
+++ b/e2e-apps/node-next/lib/notification-digest.js
@@ -17,6 +17,23 @@ function normalizeMaxItems(maxItems, totalItems) {
   return Math.min(Math.floor(maxItems), totalItems);
 }
 
+function parseCreatedAt(value) {
+  const createdAt = String(value ?? "");
+  const timestamp = Date.parse(createdAt);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function compareDigestEntries(left, right) {
+  const leftTime = parseCreatedAt(left.createdAt);
+  const rightTime = parseCreatedAt(right.createdAt);
+
+  if (leftTime !== rightTime) {
+    return leftTime - rightTime;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
 function isQueued(notification) {
   if (notification && "status" in notification) {
     return String(notification.status ?? "").toLowerCase() === QUEUED_STATUS;
@@ -67,6 +84,10 @@ export function buildRecipientDigest(notifications) {
     digestByRecipient.set(entry.recipient, bucket);
   }
 
+  for (const entries of digestByRecipient.values()) {
+    entries.sort(compareDigestEntries);
+  }
+
   return Array.from(digestByRecipient.entries())
     .sort((left, right) => left[0].localeCompare(right[0]))
     .map(([recipient, entries]) => ({ recipient, entries }));
@@ -75,11 +96,15 @@ export function buildRecipientDigest(notifications) {
 export function flushRecipientDigest(notifications, recipient, options = {}) {
   const recipientKey = normalizeRecipient(recipient);
   const queuedEntries = (notifications ?? [])
-    .map((notification, index) => ({ notification, index }))
+    .map((notification, index) => ({
+      notification,
+      index,
+      entry: toDigestEntry(notification),
+    }))
     .filter(
-      ({ notification }) =>
-        normalizeRecipient(notification?.recipient) === recipientKey && isQueued(notification),
-    );
+      ({ entry, notification }) => entry.recipient === recipientKey && isQueued(notification),
+    )
+    .sort((left, right) => compareDigestEntries(left.entry, right.entry));
 
   const maxItems = normalizeMaxItems(options.maxItems, queuedEntries.length);
   const selectedEntries = queuedEntries.slice(0, maxItems);

--- a/e2e-apps/node-next/tests/notification-digest.test.js
+++ b/e2e-apps/node-next/tests/notification-digest.test.js
@@ -40,6 +40,79 @@ test("buildRecipientDigest groups queued notifications per recipient", () => {
   ]);
 });
 
+test("buildRecipientDigest sorts entries by creation time and id", () => {
+  const notifications = [
+    {
+      id: "later",
+      recipient: "alice@example.com",
+      subject: "Later",
+      status: "queued",
+      createdAt: "2026-03-11T10:00:00Z",
+    },
+    {
+      id: "same-time-b",
+      recipient: "alice@example.com",
+      subject: "Same",
+      status: "queued",
+      createdAt: "2026-03-10T10:00:00Z",
+    },
+    {
+      id: "same-time-a",
+      recipient: "alice@example.com",
+      subject: "Same",
+      status: "queued",
+      createdAt: "2026-03-10T10:00:00Z",
+    },
+    {
+      id: "earlier",
+      recipient: "alice@example.com",
+      subject: "Earlier",
+      status: "queued",
+      createdAt: "2026-03-09T10:00:00Z",
+    },
+  ];
+
+  const digest = buildRecipientDigest(notifications.reverse());
+
+  assert.deepEqual(digest[0].entries.map((entry) => entry.id), [
+    "earlier",
+    "same-time-a",
+    "same-time-b",
+    "later",
+  ]);
+});
+
+test("flushRecipientDigest prioritizes the earliest queued notifications when limited", () => {
+  const queuedNotifications = [
+    {
+      id: "later",
+      recipient: "alex@example.com",
+      status: "queued",
+      createdAt: "2026-03-11T10:00:00Z",
+    },
+    {
+      id: "earlier",
+      recipient: "alex@example.com",
+      status: "queued",
+      createdAt: "2026-03-10T10:00:00Z",
+    },
+  ];
+
+  const result = flushRecipientDigest(queuedNotifications, "alex@example.com", {
+    maxItems: 1,
+    sentAt: "2026-03-11T12:00:00Z",
+  });
+
+  assert.equal(result.sent, 1);
+  assert.deepEqual(result.sentIds, ["earlier"]);
+  assert.equal(result.digest.notifications.length, 1);
+  assert.equal(result.digest.notifications[0].id, "earlier");
+  assert.equal(queuedNotifications[0].sent, undefined);
+  assert.equal(queuedNotifications[1].sent, true);
+  assert.equal(queuedNotifications[1].status, "sent");
+  assert.equal(queuedNotifications[1].sentAt, "2026-03-11T12:00:00Z");
+});
+
 test("flushRecipientDigest marks only recipient-scoped ids as sent", () => {
   const notifications = [
     { id: "42", recipient: "alice@example.com", subject: "A", status: "queued" },


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1110.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Added sorting helpers so recipient digests and flush prioritization rely on creation time (with ID tie-breaker) and expanded the suite to guard the ordering behavior; tests (`cd e2e-apps/node-next && npm test -- --passWithNoTests`) already pass.`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-apps/node-next`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
