### PR TITLE
healer: fix issue #1111 - Hard batch 5: Hard app: Node Next todo route contract under invalid payloads

### DIFF
--- a/e2e-apps/node-next/app/api/todos/route.js
+++ b/e2e-apps/node-next/app/api/todos/route.js
@@ -1,4 +1,5 @@
 import {
+  isTodoPayload,
   toTodoItemPayload,
   toTodoListPayload,
   todoService,
@@ -19,8 +20,8 @@ export async function POST(request) {
   } catch {
     return Response.json({ error: "invalid_json" }, { status: 400 });
   }
-  if (!payload || typeof payload !== "object" || typeof payload.title !== "string") {
-    return Response.json({ error: "title_required" }, { status: 400 });
+  if (!isTodoPayload(payload)) {
+    return Response.json({ error: "invalid_payload" }, { status: 400 });
   }
 
   try {

--- a/e2e-apps/node-next/lib/todo-service.js
+++ b/e2e-apps/node-next/lib/todo-service.js
@@ -56,6 +56,10 @@ export function normalizeTodoTitle(title) {
   return normalized;
 }
 
+export function isTodoPayload(payload) {
+  return payload !== null && typeof payload === "object" && typeof payload.title === "string";
+}
+
 function getNextTodoId(todos) {
   let maxId = 0;
 

--- a/e2e-apps/node-next/tests/todo-service.test.js
+++ b/e2e-apps/node-next/tests/todo-service.test.js
@@ -312,7 +312,7 @@ test("todo payload helpers keep the collection and item route shape stable", () 
   });
 });
 
-test("POST rejects blank and malformed titles", async () => {
+test("POST rejects blank titles with title_required", async () => {
   const todosBefore = listTodos().length;
   const blankResponse = await POST(
     new Request("http://localhost/api/todos", {
@@ -321,18 +321,42 @@ test("POST rejects blank and malformed titles", async () => {
       body: JSON.stringify({ title: "  \n\t  " }),
     }),
   );
-  const malformedResponse = await POST(
+
+  assert.equal(blankResponse.status, 400);
+  assert.deepEqual(await blankResponse.json(), { error: "title_required" });
+  assert.equal(listTodos().length, todosBefore);
+});
+
+test("POST rejects malformed payloads with invalid_payload", async () => {
+  const todosBefore = listTodos().length;
+  const missingTitleResponse = await POST(
+    new Request("http://localhost/api/todos", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    }),
+  );
+  const nonStringTitleResponse = await POST(
     new Request("http://localhost/api/todos", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ title: { text: "Ship it" } }),
     }),
   );
+  const primitivePayloadResponse = await POST(
+    new Request("http://localhost/api/todos", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(42),
+    }),
+  );
 
-  assert.equal(blankResponse.status, 400);
-  assert.deepEqual(await blankResponse.json(), { error: "title_required" });
-  assert.equal(malformedResponse.status, 400);
-  assert.deepEqual(await malformedResponse.json(), { error: "title_required" });
+  assert.equal(missingTitleResponse.status, 400);
+  assert.deepEqual(await missingTitleResponse.json(), { error: "invalid_payload" });
+  assert.equal(nonStringTitleResponse.status, 400);
+  assert.deepEqual(await nonStringTitleResponse.json(), { error: "invalid_payload" });
+  assert.equal(primitivePayloadResponse.status, 400);
+  assert.deepEqual(await primitivePayloadResponse.json(), { error: "invalid_payload" });
   assert.equal(listTodos().length, todosBefore);
 });
 


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1111.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `POST route now leans on `isTodoPayload` from `lib/todo-service.js` so malformed bodies hit `invalid_payload` while blank titles still surface `title_required`, and the expanded tests separate those cases and keep todo count stable; validation: `cd e2e-apps/...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-apps/node-next`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
