### PR TITLE
healer: fix issue #1109 - Hard batch 3: Hard app: Nobi portfolio engine weirdness

### DIFF
--- a/e2e-apps/nobi-owl-trader/api/portfolio.py
+++ b/e2e-apps/nobi-owl-trader/api/portfolio.py
@@ -531,6 +531,12 @@ class PortfolioEngine:
 
         return max_drawdown
 
+    @staticmethod
+    def _allocate_fee_for_amount(fee: float, amount: float, total: float) -> float:
+        if total <= 0 or amount <= 0:
+            return 0.0
+        return fee * (amount / total)
+
     def update_positions_from_trade(self, trade: Trade) -> None:
         """
         Update positions table when a trade executes.
@@ -543,6 +549,7 @@ class PortfolioEngine:
             trade: The trade that was executed
         """
         current_position = self.position_repo.get_by_symbol(trade.symbol)
+        allow_shorts = os.getenv("ALLOW_SHORT_POSITIONS", "false").lower() == "true"
 
         if trade.side == "buy":
             if current_position is None:
@@ -557,8 +564,8 @@ class PortfolioEngine:
                     last_updated=trade.timestamp
                 )
                 self.position_repo.upsert(position)
-            else:
-                # Update existing position
+            elif current_position.side == "long":
+                # Update existing long position
                 new_total_cost = current_position.total_cost + (trade.amount * trade.price + trade.fee)
                 new_amount = current_position.amount + trade.amount
                 new_avg_price = (new_total_cost / new_amount) if new_amount > 0 else 0.0
@@ -568,16 +575,48 @@ class PortfolioEngine:
                     amount=new_amount,
                     avg_entry_price=new_avg_price,
                     total_cost=new_total_cost,
-                    side=current_position.side,
+                    side="long",
                     opened_at=current_position.opened_at,
                     last_updated=trade.timestamp
                 )
                 self.position_repo.upsert(position)
+            else:
+                # Closing or reducing a short position
+                if trade.amount >= current_position.amount:
+                    closing_fee = self._allocate_fee_for_amount(trade.fee, current_position.amount, trade.amount)
+                    remaining_fee = trade.fee - closing_fee
+                    leftover_amount = trade.amount - current_position.amount
+                    self.position_repo.delete(trade.symbol)
+
+                    if leftover_amount > 1e-8:
+                        position = Position(
+                            symbol=trade.symbol,
+                            amount=leftover_amount,
+                            avg_entry_price=trade.price,
+                            total_cost=leftover_amount * trade.price + max(remaining_fee, 0.0),
+                            side="long",
+                            opened_at=trade.timestamp,
+                            last_updated=trade.timestamp
+                        )
+                        self.position_repo.upsert(position)
+                else:
+                    new_amount = current_position.amount - trade.amount
+                    new_total_cost = current_position.total_cost * (new_amount / current_position.amount)
+
+                    position = Position(
+                        symbol=trade.symbol,
+                        amount=new_amount,
+                        avg_entry_price=current_position.avg_entry_price,
+                        total_cost=new_total_cost,
+                        side="short",
+                        opened_at=current_position.opened_at,
+                        last_updated=trade.timestamp
+                    )
+                    self.position_repo.upsert(position)
 
         elif trade.side == "sell":
             if current_position is None:
                 # Check if shorting is allowed (disabled by default for spot trading)
-                allow_shorts = os.getenv("ALLOW_SHORT_POSITIONS", "false").lower() == "true"
                 if not allow_shorts:
                     logger.warning(f"Sell order for {trade.symbol} with no existing position - ignoring (shorting disabled)")
                     return
@@ -593,14 +632,49 @@ class PortfolioEngine:
                     last_updated=trade.timestamp
                 )
                 self.position_repo.upsert(position)
+            elif current_position.side == "short":
+                # Increase short exposure
+                new_amount = current_position.amount + trade.amount
+                new_total_cost = current_position.total_cost + (trade.amount * trade.price - trade.fee)
+                new_avg_price = (new_total_cost / new_amount) if new_amount > 0 else 0.0
+
+                position = Position(
+                    symbol=trade.symbol,
+                    amount=new_amount,
+                    avg_entry_price=new_avg_price,
+                    total_cost=new_total_cost,
+                    side="short",
+                    opened_at=current_position.opened_at,
+                    last_updated=trade.timestamp
+                )
+                self.position_repo.upsert(position)
             else:
-                # Reduce or close position
+                # Reduce or close long position, possibly flipping to short
                 new_amount = current_position.amount - trade.amount
 
-                if new_amount <= 1e-8:  # Position closed
+                if new_amount <= 1e-8:
+                    closing_fee = self._allocate_fee_for_amount(trade.fee, current_position.amount, trade.amount)
+                    remaining_fee = trade.fee - closing_fee
+                    leftover_amount = trade.amount - current_position.amount
                     self.position_repo.delete(trade.symbol)
+
+                    if leftover_amount > 1e-8:
+                        if not allow_shorts:
+                            logger.warning(f"Sell order for {trade.symbol} exceeded available long position and shorting is disabled; ignoring excess.")
+                            return
+
+                        position = Position(
+                            symbol=trade.symbol,
+                            amount=leftover_amount,
+                            avg_entry_price=trade.price,
+                            total_cost=leftover_amount * trade.price - max(remaining_fee, 0.0),
+                            side="short",
+                            opened_at=trade.timestamp,
+                            last_updated=trade.timestamp
+                        )
+                        self.position_repo.upsert(position)
                 else:
-                    # Reduce position size but keep same avg entry price
+                    # Reduce long position size but keep same avg entry price
                     # Proportionally reduce total cost
                     new_total_cost = current_position.total_cost * (new_amount / current_position.amount)
 
@@ -609,7 +683,7 @@ class PortfolioEngine:
                         amount=new_amount,
                         avg_entry_price=current_position.avg_entry_price,
                         total_cost=new_total_cost,
-                        side=current_position.side,
+                        side="long",
                         opened_at=current_position.opened_at,
                         last_updated=trade.timestamp
                     )

--- a/e2e-apps/nobi-owl-trader/tests/test_portfolio.py
+++ b/e2e-apps/nobi-owl-trader/tests/test_portfolio.py
@@ -548,6 +548,48 @@ class TestPositionUpdates:
         position = portfolio_engine.position_repo.get_by_symbol("BTC/USDT")
         assert position is None  # Position should be closed
 
+    def test_sell_exceeding_long_flips_to_short(self, trade_repo, portfolio_engine, monkeypatch):
+        """Test selling more than the long position opens a short when allowed."""
+        monkeypatch.setenv("ALLOW_SHORT_POSITIONS", "true")
+        base_time = int(datetime.now().timestamp())
+
+        buy_trade = create_trade("buy-1", "BTC/USDT", "buy", 2.0, 50000.0, base_time, fee=100.0)
+        trade_repo.create(buy_trade)
+        portfolio_engine.update_positions_from_trade(buy_trade)
+
+        sell_trade = create_trade("sell-1", "BTC/USDT", "sell", 3.0, 51000.0, base_time + 100, fee=90.0)
+        trade_repo.create(sell_trade)
+        portfolio_engine.update_positions_from_trade(sell_trade)
+
+        position = portfolio_engine.position_repo.get_by_symbol("BTC/USDT")
+        assert position is not None
+        assert position.side == "short"
+        assert abs(position.amount - 1.0) < 1e-8
+        assert abs(position.avg_entry_price - 51000.0) < 0.01
+        # Remaining fee should be 90 * ( (3.0 - 2.0) / 3.0 ) = 30. Total cost = 1 * 51000 - 30.
+        assert abs(position.total_cost - 50970.0) < 0.01
+
+    def test_buy_exceeding_short_flips_to_long(self, trade_repo, portfolio_engine, monkeypatch):
+        """Test buying more than the short position closes it and opens a long."""
+        monkeypatch.setenv("ALLOW_SHORT_POSITIONS", "true")
+        base_time = int(datetime.now().timestamp())
+
+        sell_trade = create_trade("sell-1", "ETH/USDT", "sell", 2.0, 3000.0, base_time, fee=30.0)
+        trade_repo.create(sell_trade)
+        portfolio_engine.update_positions_from_trade(sell_trade)
+
+        buy_trade = create_trade("buy-1", "ETH/USDT", "buy", 3.0, 2800.0, base_time + 100, fee=45.0)
+        trade_repo.create(buy_trade)
+        portfolio_engine.update_positions_from_trade(buy_trade)
+
+        position = portfolio_engine.position_repo.get_by_symbol("ETH/USDT")
+        assert position is not None
+        assert position.side == "long"
+        assert abs(position.amount - 1.0) < 1e-8
+        # Closing fee share = 45 * (2/3) = 30, remaining fee = 15. Total cost = 1 * 2800 + 15.
+        assert abs(position.total_cost - 2815.0) < 0.01
+        assert abs(position.avg_entry_price - 2800.0) < 0.01
+
 
 class TestEdgeCases:
     """Test edge cases and error handling"""


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1109.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Portfolio engine now allocates fees proportionally so trades that flip sides (long ↔ short) cleanly delete or flip positions while honoring ALLOW_SHORT_POSITIONS, and unit tests cover over-selling and over-buying scenarios to lock in the regression.`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/nobi-owl-trader`
- Targeted tests: `tests/test_portfolio.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
