### PR TITLE
healer: fix issue #1113 - Hard batch 7: Hard app: FastAPI token refresh flow

### DIFF
--- a/e2e-apps/python-fastapi/app/token_service.py
+++ b/e2e-apps/python-fastapi/app/token_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -78,10 +79,9 @@ def _resolve_expiry(
     *,
     fallback: datetime,
 ) -> datetime:
-    if isinstance(raw_expires_at, datetime):
-        if raw_expires_at.tzinfo is None:
-            return raw_expires_at.replace(tzinfo=UTC)
-        return raw_expires_at
+    parsed_expiry = _parse_expiry(raw_expires_at)
+    if parsed_expiry is not None:
+        return parsed_expiry
 
     if raw_expires_in is None:
         return fallback
@@ -94,3 +94,57 @@ def _resolve_expiry(
     if expires_in < 0:
         return fallback
     return now + timedelta(seconds=expires_in)
+
+
+def _parse_expiry(raw_expires_at: object) -> datetime | None:
+    if isinstance(raw_expires_at, datetime):
+        return raw_expires_at.replace(tzinfo=UTC) if raw_expires_at.tzinfo is None else raw_expires_at
+
+    if isinstance(raw_expires_at, (int, float)):
+        return _datetime_from_timestamp(float(raw_expires_at))
+
+    if isinstance(raw_expires_at, str):
+        parsed = _parse_iso_datetime(raw_expires_at)
+        if parsed is not None:
+            return parsed
+        return _parse_timestamp_string(raw_expires_at)
+
+    return None
+
+
+def _datetime_from_timestamp(value: float) -> datetime | None:
+    if not math.isfinite(value):
+        return None
+
+    try:
+        return datetime.fromtimestamp(value, tz=UTC)
+    except (OSError, OverflowError):
+        return None
+
+
+def _parse_iso_datetime(value: str) -> datetime | None:
+    trimmed = value.strip()
+    if not trimmed:
+        return None
+
+    normalized = trimmed
+    if normalized.endswith("Z") and len(normalized) > 1:
+        normalized = f"{normalized[:-1]}+00:00"
+
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def _parse_timestamp_string(value: str) -> datetime | None:
+    trimmed = value.strip()
+    if not trimmed:
+        return None
+    try:
+        timestamp = float(trimmed)
+    except ValueError:
+        return None
+    return _datetime_from_timestamp(timestamp)

--- a/e2e-apps/python-fastapi/tests/test_token_service.py
+++ b/e2e-apps/python-fastapi/tests/test_token_service.py
@@ -120,3 +120,46 @@ def test_refresh_access_token_uses_provider_expiry_when_available() -> None:
     assert refreshed.access_token == "updated-access"
     assert refreshed.refresh_token == "refresh-me"
     assert refreshed.expires_at == refreshed_expiry
+
+
+def test_refresh_access_token_parses_iso_expires_at_string() -> None:
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    bundle = TokenBundle(
+        access_token="current-access",
+        refresh_token="refresh-me",
+        expires_at=now,
+    )
+    iso_timestamp = "2026-01-01T02:30:00Z"
+
+    refreshed = refresh_access_token(
+        bundle,
+        lambda _refresh_token: {
+            "access_token": "updated-access",
+            "expires_at": iso_timestamp,
+        },
+        now=now,
+    )
+
+    assert refreshed.expires_at == datetime(2026, 1, 1, 2, 30, tzinfo=UTC)
+
+
+def test_refresh_access_token_parses_numeric_expires_at_timestamp() -> None:
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    bundle = TokenBundle(
+        access_token="current-access",
+        refresh_token="refresh-me",
+        expires_at=now,
+    )
+    expected_expiry = datetime(2027, 4, 1, tzinfo=UTC)
+    timestamp = int(expected_expiry.timestamp())
+
+    refreshed = refresh_access_token(
+        bundle,
+        lambda _refresh_token: {
+            "access_token": "updated-access",
+            "expires_at": timestamp,
+        },
+        now=now,
+    )
+
+    assert refreshed.expires_at == expected_expiry


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1113.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Scoped token refresh parsing enhancements to handle ISO timestamps, numeric timestamps, and datetimes before falling back to expires_in, plus regression tests for the new coverage; targeted validation `pytest -q` passes as required.`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/python-fastapi`
- Targeted tests: `tests/test_token_service.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
