### PR TITLE
healer: fix issue #1114 - Hard batch 8: Hard smoke: Django numeric string compatibility

### DIFF
--- a/e2e-smoke/py-django/app/add.py
+++ b/e2e-smoke/py-django/app/add.py
@@ -1,4 +1,22 @@
+def _unwrap_value(value: object) -> object:
+    seen_ids = set()
+
+    while hasattr(value, "value"):
+        current_id = id(value)
+        if current_id in seen_ids:
+            break
+        seen_ids.add(current_id)
+
+        next_value = getattr(value, "value")
+        if next_value is value:
+            break
+        value = next_value
+
+    return value
+
+
 def _coerce_int(value: object) -> int:
+    value = _unwrap_value(value)
     if isinstance(value, bool):
         raise TypeError("boolean operands are not allowed")
     if isinstance(value, str):

--- a/e2e-smoke/py-django/tests/test_add.py
+++ b/e2e-smoke/py-django/tests/test_add.py
@@ -18,6 +18,17 @@ def test_add_accepts_stringable_values() -> None:
     assert add(DjangoStringable("2"), DjangoStringable("3")) == 5
 
 
+def test_add_unwraps_value_wrappers() -> None:
+    class DjangoValueWrapper:
+        def __init__(self, value: object) -> None:
+            self.value = value
+
+    wrapped = DjangoValueWrapper(DjangoValueWrapper(" 2 "))
+    unwrapped = DjangoValueWrapper("3")
+
+    assert add(wrapped, unwrapped) == 5
+
+
 def test_add_accepts_numeric_string_wrappers_with_broken_int_conversion() -> None:
     class DjangoBoundaryValue:
         def __init__(self, value: str) -> None:


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1114.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Introduced `_unwrap_value` in `e2e-smoke/py-django/app/add.py` so `_coerce_int` navigates `.value` chains safely before existing validations, and added `test_add_unwraps_value_wrappers` in `e2e-smoke/py-django/tests/test_add.py` to cover the new behavior. T...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-smoke/py-django`
- Targeted tests: `tests/test_add.py`
- Local full gate: `passed`
- Docker full gate: `skipped` (reason `explicit_validation_commands`)

_Built with a little hustle by Flow Healer 🤖✨_
