### PR TITLE
healer: fix issue #1115 - Hard batch 9: Hard smoke: pandas helper stays pandas-specific

### DIFF
--- a/e2e-smoke/py-data-pandas/app/add.py
+++ b/e2e-smoke/py-data-pandas/app/add.py
@@ -2,9 +2,15 @@ import pandas as pd
 from typing import Any
 
 
+def _is_pandas_addable(value: Any) -> bool:
+    return isinstance(value, pd.core.base.PandasObject) and callable(getattr(value, "add", None))
+
+
 def add(a: Any, b: Any) -> Any:
-    if isinstance(a, pd.core.base.PandasObject) and callable(getattr(a, "add", None)):
+    if _is_pandas_addable(a):
         return a.add(b)
+    if _is_pandas_addable(b):
+        return b.add(a)
     return a + b
 
 

--- a/e2e-smoke/py-data-pandas/tests/test_add.py
+++ b/e2e-smoke/py-data-pandas/tests/test_add.py
@@ -83,6 +83,26 @@ def test_add_uses_native_add_for_pandas_objects_only() -> None:
     assert result.used_native_add is True
 
 
+def test_add_prefers_pandas_add_when_second_operand_is_pandas_object() -> None:
+    class TrackingPandasObject(pd.core.base.PandasObject):
+        def __init__(self, value: int) -> None:
+            self.value = value
+            self.used_native_add = False
+
+        def add(self, other: int) -> "TrackingPandasObject":
+            result = TrackingPandasObject(self.value + other)
+            result.used_native_add = True
+            return result
+
+        def __radd__(self, other: int) -> "TrackingPandasObject":
+            raise AssertionError("pandas add should be used without falling back to __radd__")
+
+    result = add(2, TrackingPandasObject(1))
+
+    assert result.value == 3
+    assert result.used_native_add is True
+
+
 def test_add_many_with_scalars() -> None:
     assert add_many(2, 3, 4) == 9
 


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1115.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `add now prefers pandas’ .add implementation for either operand and keeps a helper that detects pandas addable objects; test suite adds tracking coverage ensuring pandas add is invoked even when it’s the right-hand operand. Validation: `cd e2e-smoke/py-data-...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-smoke/py-data-pandas`
- Targeted tests: `tests/test_add.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
