### PR TITLE
healer: fix issue #1153 - Sandbox stress task 14: Mega final app: Node Next todo route and service contrac

### DIFF
--- a/e2e-apps/node-next/lib/todo-service.js
+++ b/e2e-apps/node-next/lib/todo-service.js
@@ -106,9 +106,20 @@ function normalizeCompletedFlag(value) {
   return value === 1;
 }
 
+function getPublicTodoId(value) {
+  const normalizedId = normalizeTodoId(value);
+  if (/^-?\d+$/.test(normalizedId)) {
+    const numericId = Number.parseInt(normalizedId, 10);
+    if (Number.isSafeInteger(numericId)) {
+      return numericId;
+    }
+  }
+  return normalizedId;
+}
+
 export function toPublicTodo(todo) {
   return {
-    id: Number(normalizeTodoId(todo?.id)),
+    id: getPublicTodoId(todo?.id),
     title: todo.title,
     completed: todo.completed,
     completedAt: todo.completedAt ?? null,

--- a/e2e-apps/node-next/tests/todo-service.test.js
+++ b/e2e-apps/node-next/tests/todo-service.test.js
@@ -312,6 +312,62 @@ test("todo payload helpers keep the collection and item route shape stable", () 
   });
 });
 
+test("todo payload helpers preserve non-numeric ids", () => {
+  const todos = [
+    {
+      id: "task-09",
+      title: "Legacy id",
+      completed: true,
+      completedAt: "2026-03-08T12:05:00.000Z",
+    },
+    {
+      id: "legacy:prefixed",
+      title: "Prefixed legacy id",
+      completed: false,
+      completedAt: null,
+    },
+  ];
+
+  assert.deepEqual(toPublicTodoList(todos), [
+    {
+      id: "task-09",
+      title: "Legacy id",
+      completed: true,
+      completedAt: "2026-03-08T12:05:00.000Z",
+    },
+    {
+      id: "legacy:prefixed",
+      title: "Prefixed legacy id",
+      completed: false,
+      completedAt: null,
+    },
+  ]);
+  assert.deepEqual(toTodoListPayload(todos), {
+    todos: [
+      {
+        id: "task-09",
+        title: "Legacy id",
+        completed: true,
+        completedAt: "2026-03-08T12:05:00.000Z",
+      },
+      {
+        id: "legacy:prefixed",
+        title: "Prefixed legacy id",
+        completed: false,
+        completedAt: null,
+      },
+    ],
+  });
+  assert.deepEqual(toTodoItemPayload(todos[1]), {
+    item: {
+      id: "legacy:prefixed",
+      title: "Prefixed legacy id",
+      completed: false,
+      completedAt: null,
+    },
+  });
+});
+
 test("POST rejects blank titles with title_required", async () => {
   const todosBefore = listTodos().length;
   const blankResponse = await POST(


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1153.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Added `getPublicTodoId` so `toPublicTodo` exposes safe integers yet leaves legacy non-numeric ids untouched and backed the behavior with a new payload-helper regression test; tests: `cd e2e-apps/node-next && npm test -- --passWithNoTests`.`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-apps/node-next`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
