### PR TITLE
healer: fix issue #1154 - Sandbox stress task 15: Mega final app: Node Next export service contract

### DIFF
--- a/e2e-apps/node-next/lib/export-service.js
+++ b/e2e-apps/node-next/lib/export-service.js
@@ -1,4 +1,4 @@
-const TODO_EXPORT_COLUMNS = ["id", "title", "completed"];
+export const TODO_EXPORT_COLUMNS = ["id", "title", "completed", "completedAt"];
 
 export function escapeCsvValue(value) {
   const normalized = String(value ?? "");

--- a/e2e-apps/node-next/tests/export-service.test.js
+++ b/e2e-apps/node-next/tests/export-service.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  TODO_EXPORT_COLUMNS,
   escapeCsvValue,
   toCsvRows,
   toTodoCsv,
@@ -24,9 +25,9 @@ test("toCsvRows keeps a stable header row and serializes values in order", () =>
           completed: true,
         },
       ],
-      ["id", "title", "completed"],
+      TODO_EXPORT_COLUMNS,
     ),
-    ["id,title,completed", "7,Ship dashboard,true"],
+    [TODO_EXPORT_COLUMNS.join(","), "7,Ship dashboard,true,"],
   );
 });
 
@@ -42,16 +43,17 @@ test("toTodoCsv exports todos with stable columns and escaped values", () => {
         id: 2,
         title: "Ship CSV",
         completed: true,
+        completedAt: "2026-03-13T00:00:00.000Z",
       },
     ]),
     [
-      "id,title,completed",
-      "1,\"Review, \"\"export\"\"\nnotes\",false",
-      "2,Ship CSV,true",
+      TODO_EXPORT_COLUMNS.join(","),
+      "1,\"Review, \"\"export\"\"\nnotes\",false,",
+      "2,Ship CSV,true,2026-03-13T00:00:00.000Z",
     ].join("\n"),
   );
 });
 
 test("toTodoCsv returns only the header row for an empty list", () => {
-  assert.equal(toTodoCsv([]), "id,title,completed");
+  assert.equal(toTodoCsv([]), TODO_EXPORT_COLUMNS.join(","));
 });


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1154.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Added shared TODO_EXPORT_COLUMNS (now including completedAt) exported for reuse, and updated export-service tests to assert the expanded header plus completedAt handling and empty list case; validation: `cd e2e-apps/node-next && npm test -- --passWithNoTests`.`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-apps/node-next`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
