### PR TITLE
healer: fix issue #1157 - Sandbox stress task 18: Mega final app: Python FastAPI domain service

### DIFF
--- a/e2e-apps/python-fastapi/app/service.py
+++ b/e2e-apps/python-fastapi/app/service.py
@@ -8,6 +8,7 @@ from app.repository import ServiceRecord, ServiceRepository
 
 from .repository import InMemoryTodoRepository, TodoRecord
 
+SERVICE_NOT_FOUND = "service_not_found"
 TODO_NOT_FOUND = "todo_not_found"
 
 
@@ -17,6 +18,13 @@ class DomainService:
 
     def list_services(self) -> list[ServiceRecord]:
         return deepcopy(self._repository.list_services())
+
+    def get_service(self, service_id: str) -> ServiceRecord:
+        normalized_id = self._require_text(service_id, "service_id_required")
+        for record in self._repository.list_services():
+            if record.service_id == normalized_id:
+                return deepcopy(record)
+        raise KeyError(SERVICE_NOT_FOUND)
 
     def create_service(
         self,

--- a/e2e-apps/python-fastapi/tests/test_domain_service.py
+++ b/e2e-apps/python-fastapi/tests/test_domain_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from app.repository import InMemoryTodoRepository, ServiceRecord, ServiceRepository, TodoRecord
-from app.service import DomainService, TodoService
+from app.service import DomainService, SERVICE_NOT_FOUND, TodoService
 
 
 class _FalsyServices(list[ServiceRecord]):
@@ -155,6 +155,41 @@ def test_domain_service_create_service_rejects_invalid_fields() -> None:
 
     with pytest.raises(ValueError, match="service_id_required"):  # type: ignore[arg-type]
         service.create_service(None, "billing")
+
+
+def test_domain_service_get_service_returns_detached_record_by_id() -> None:
+    repository = ServiceRepository(
+        [
+            ServiceRecord(
+                service_id="svc-1",
+                name="billing",
+                tags=["core"],
+                metadata={"region": "us-west-2"},
+            )
+        ]
+    )
+    service = DomainService(repository)
+
+    retrieved = service.get_service("  svc-1  ")
+    retrieved.tags.append("mutated")
+    retrieved.metadata["region"] = "eu-central-1"
+
+    fresh = service.get_service("svc-1")
+    repository_services = repository.list_services()
+
+    assert fresh.name == "billing"
+    assert fresh.tags == ["core"]
+    assert fresh.metadata == {"region": "us-west-2"}
+    assert repository_services[0].metadata == {"region": "us-west-2"}
+
+
+def test_domain_service_get_service_raises_for_unknown_id() -> None:
+    service = DomainService(ServiceRepository())
+
+    with pytest.raises(KeyError) as exc_info:
+        service.get_service("missing")
+
+    assert exc_info.value.args[0] == SERVICE_NOT_FOUND
 
 
 def test_create_todo_trims_title_and_assigns_incrementing_ids() -> None:


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1157.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Added `DomainService.get_service` plus `SERVICE_NOT_FOUND` sentinel and scoped tests covering successful lookup, detached records, and missing-ID errors in `tests/test_domain_service.py`; validation: `cd e2e-apps/python-fastapi && pytest -q`.`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/python-fastapi`
- Targeted tests: `tests/test_domain_service.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
