### PR TITLE
healer: fix issue #1158 - Sandbox stress task 19: Mega final app: Python FastAPI importer behavior

### DIFF
--- a/e2e-apps/python-fastapi/app/importer.py
+++ b/e2e-apps/python-fastapi/app/importer.py
@@ -57,7 +57,7 @@ def _extract_items(payload: object) -> list[Mapping[str, object]]:
 
 
 def _parse_payload(payload: object) -> object:
-    if isinstance(payload, str):
+    if isinstance(payload, (str, bytes, bytearray)):
         try:
             return json.loads(payload)
         except json.JSONDecodeError as exc:

--- a/e2e-apps/python-fastapi/tests/test_importer.py
+++ b/e2e-apps/python-fastapi/tests/test_importer.py
@@ -35,6 +35,18 @@ def test_import_todos_accepts_mapping_with_items_key() -> None:
     assert imported[0].title == "Backfill analytics"
 
 
+@pytest.mark.parametrize("payload", [
+    b"[{\"title\": \"Bytes import\", \"completed\": true}]",
+    bytearray(b"[{\"title\": \"Bytearray import\", \"completed\": true}]")
+])
+def test_import_todos_accepts_bytes_like_payload(payload: bytes) -> None:
+    imported = import_todos(payload)
+
+    assert len(imported) == 1
+    assert imported[0].title in {"Bytes import", "Bytearray import"}
+    assert imported[0].completed is True
+
+
 def test_import_todos_rejects_invalid_payload_shapes() -> None:
     with pytest.raises(ValueError, match="items_payload_required"):
         import_todos(None)


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1158.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Importer now accepts bytes/bytearray payloads by treating them the same as str when JSON-decoding, and the new parametrized importer test confirms bytes-like inputs succeed; `pytest -q` passed (targeted `tests/test_importer.py`; full suite 51 tests).`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `python`
- Execution root: `e2e-apps/python-fastapi`
- Targeted tests: `tests/test_importer.py`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
