### PR TITLE
healer: fix issue #1161 - Sandbox stress task 22: Mega final app: Java Spring login flow

### DIFF
--- a/e2e-apps/java-spring-web/src/main/java/example/web/LoginController.java
+++ b/e2e-apps/java-spring-web/src/main/java/example/web/LoginController.java
@@ -37,7 +37,7 @@ public class LoginController {
             return defaultValue;
         }
         String trimmedSessionUser = rawSessionUser.trim();
-        if (!trimmedSessionUser.matches("[A-Za-z0-9._%+-@]+")) {
+        if (!trimmedSessionUser.matches("[A-Za-z0-9._%+-@']+")) {
             return defaultValue;
         }
         return trimmedSessionUser;
@@ -48,6 +48,7 @@ public class LoginController {
             .replace("&", "&amp;")
             .replace("<", "&lt;")
             .replace(">", "&gt;")
-            .replace("\"", "&quot;");
+            .replace("\"", "&quot;")
+            .replace("'", "&#x27;");
     }
 }

--- a/e2e-apps/java-spring-web/src/test/java/example/web/HealthControllerTest.java
+++ b/e2e-apps/java-spring-web/src/test/java/example/web/HealthControllerTest.java
@@ -4,6 +4,7 @@ public class HealthControllerTest {
     public static void main(String[] args) {
         healthEndpointReturnsOk();
         loginFormRendersDeterministicEvidenceMarker();
+        loginFormEscapesSessionUser();
         loginEndpointIssuesCookieBackedSession();
         loginEndpointFallsBackForBlankEmailInput();
         loginEndpointFallsBackForMalformedEmailInput();
@@ -20,6 +21,18 @@ public class HealthControllerTest {
         ResponsePlan response = new LoginController().loginForm("");
         assertEquals(200, response.status(), "login form status");
         assertContains(response.body(), "Evidence TC 3", "login form evidence marker");
+    }
+
+    private static void loginFormEscapesSessionUser() {
+        String sessionUserWithApostrophe = "seeded-admin'o@example.com";
+        ResponsePlan response = new LoginController().loginForm(sessionUserWithApostrophe);
+        assertEquals(200, response.status(), "login form status");
+        assertContains(
+            response.body(),
+            "seeded-admin&#x27;o@example.com",
+            "login form escapes apostrophes in session user"
+        );
+        assertNotContains(response.body(), sessionUserWithApostrophe, "login form raw session user");
     }
 
     private static void loginEndpointIssuesCookieBackedSession() {
@@ -71,6 +84,12 @@ public class HealthControllerTest {
     private static void assertContains(String body, String expected, String label) {
         if (body == null || !body.contains(expected)) {
             throw new AssertionError(label + " missing expected fragment: " + expected);
+        }
+    }
+
+    private static void assertNotContains(String body, String unexpected, String label) {
+        if (body != null && body.contains(unexpected)) {
+            throw new AssertionError(label + " contains unexpected fragment: " + unexpected);
         }
     }
 }


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1161.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `LoginController now allows apostrophes in normalized session identities and escapes them before rendering so `seeded-admin'o@example.com` displays safely; HealthControllerTest adds regression ensuring the login form renders escaped apostrophes and adds `ass...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `java_gradle`
- Execution root: `e2e-apps/java-spring-web`
- Local full gate: `passed`

_Built with a little hustle by Flow Healer 🤖✨_
