### PR TITLE
healer: fix issue #1239 - Haiku test: change body background to neon pink in node-next app

### DIFF
--- a/e2e-apps/node-next/app/layout.js
+++ b/e2e-apps/node-next/app/layout.js
@@ -6,7 +6,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body style={{ fontFamily: "system-ui, sans-serif", margin: "2rem" }}>
+      <body style={{ fontFamily: "system-ui, sans-serif", margin: "2rem", backgroundColor: "#FF00FF" }}>
         <div style={{ display: "grid", gap: "1.5rem" }}>
           <header>
             <h1>Flow Healer Todo Sandbox</h1>


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1239.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `The neon pink background (#FF00FF) has been successfully applied to the body element in app/layout.js via a minimal, targeted inline style addition. The patch matches the spec exactly, adds no extraneous changes, and all 42 validation tests pass. Visual ver...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-apps/node-next`
- Local full gate: `passed`
- Docker full gate: `skipped` (reason `explicit_validation_commands`)

_Built with a little hustle by Flow Healer 🤖✨_
