### PR TITLE
healer: fix issue #1252 - Node smoke: getUserById returns undefined instead of throwing for unknown ids

### DIFF
--- a/e2e-smoke/node/src/users.js
+++ b/e2e-smoke/node/src/users.js
@@ -12,11 +12,11 @@ const USERS = [
  * Throws RangeError when no user matches.
  */
 export function getUserById(id) {
-  // BUG: missing guard — returns undefined instead of throwing when not found.
   const user = USERS.find(u => u.id === id);
 
-  // Debug logging left in by accident — leaks PII to stdout.
-  console.log('[users] lookup:', id, '→', user?.email, user?.phone, user?.taxId);
+  if (!user) {
+    throw new RangeError(`No user found with id ${id}`);
+  }
 
   return user;
 }


### PR DESCRIPTION
Flow Healer rolled in with an automated proposal for issue #1252.

A quick heads-up before you review: this branch was assembled by the agent, then checked against the current validation gates.

### Verification
- Verifier: `Patch correctly addresses both issue requirements: (1) added RangeError throw with exact message format `No user found with id <id>` for missing users, (2) removed PII-leaking debug console.log and associated comment. Change is scoped to the single target f...`

### Test Summary
- Test gates: `passed`
- Failed tests: `0`
- Gate mode: `local_only`
- Language: `node`
- Execution root: `e2e-smoke/node`
- Local full gate: `passed`
- Docker full gate: `skipped` (reason `explicit_validation_commands`)

_Built with a little hustle by Flow Healer 🤖✨_
