### PR TITLE
Haiku docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The TUI shows a **Review Queue** of draft PRs ready to approve, a **Blocked** ta
 ## Documentation
 
 - [docs/onboarding.md](docs/onboarding.md) — 15-minute setup guide
+- [docs/haiku.md](docs/haiku.md) — Claude Haiku configuration and usage
+- [docs/agentic-coding.md](docs/agentic-coding.md) — AI agent capabilities and connectors
 - [docs/mvp.md](docs/mvp.md) — what's in scope at MVP
 - [docs/safe-scope.md](docs/safe-scope.md) — file scope rules and examples
 - [docs/operator-workflow.md](docs/operator-workflow.md) — TUI / CLI operator guide

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,8 @@ These documents define current repo behavior and should be updated in the same c
 
 ## Supporting References
 
+- [haiku.md](haiku.md): concise Haiku configuration guide
+- [agentic-coding.md](agentic-coding.md): AI agent capabilities, connectors, and task specifications
 - [automated-coding-with-claude-haiku.md](automated-coding-with-claude-haiku.md): how Claude Haiku powers automated healing and code generation in Flow Healer
 - [contributing.md](contributing.md): contributor expectations
 - [harness-reliability-runbook.md](harness-reliability-runbook.md): focused browser-harness operations guidance

--- a/docs/agentic-coding.md
+++ b/docs/agentic-coding.md
@@ -1,0 +1,100 @@
+# Agentic Coding
+
+Flow Healer enables AI-powered automated code repair through its agentic coding capabilities. This document covers how Flow Healer uses AI agents to understand issues, generate fixes, and validate solutions.
+
+## How Agentic Coding Works
+
+Flow Healer transforms GitHub issues into structured task specifications that AI agents can understand and execute:
+
+1. **Issue Parsing**: The system parses issue titles, descriptions, and validation commands into a `HealerTaskSpec`
+2. **Agent Execution**: An AI connector (Codex, Claude, or Haiku) generates a fix based on the task specification
+3. **Validation**: The fix is applied to an isolated worktree and validated against the specified tests/commands
+4. **Evidence Collection**: Successful fixes include evidence (test output, logs) in the draft PR
+
+## Supported Agents
+
+### OpenAI Codex
+
+Codex is Flow Healer's primary agentic backend:
+
+```yaml
+service:
+  connector_backend: app_server  # or exec
+  connector_model: gpt-5.1-codex-mini
+```
+
+Features:
+- Native multi-agent support (`healer_codex_native_multi_agent_enabled`)
+- Subagent orchestration for complex tasks
+- App-server mode for persistent sessions
+- Exec mode for stateless invocations
+
+### Claude (Haiku, Sonnet, Opus)
+
+Anthropic's Claude models can power Flow Healer:
+
+```yaml
+service:
+  connector_backend: claude_cli
+  connector_model: claude-sonnet-4-20250514
+```
+
+### Other Backends
+
+Flow Healer supports multiple connector backends:
+- `gemini_cli` — Google's Gemini
+- `cline` — Cline CLI
+- `kilo_cli` — Kilo CLI
+
+See [connectors.md](connectors.md) for full backend documentation.
+
+## Native Multi-Agent Recovery
+
+When a fix fails validation, Flow Healer can invoke Codex's native multi-agent system to recover:
+
+```yaml
+repos:
+  - repo_slug: owner/repo
+    healer_codex_native_multi_agent_enabled: true
+    healer_codex_native_multi_agent_max_subagents: 3
+```
+
+This spawns subagents to:
+- Analyze the failure context
+- Propose alternative approaches
+- Execute recovery strategies
+
+## Task Specification
+
+Every agent receives a structured task spec containing:
+
+- **Task kind**: The category of work (test_fix, config_update, etc.)
+- **Execution root**: The directory or file to modify
+- **Required outputs**: Files that must be changed
+- **Input-only context**: Reference files that shouldn't be modified
+- **Validation commands**: How to verify the fix
+- **Runtime profile**: Language, framework, and environment details
+
+See [issue-contracts.md](issue-contracts.md) for the full specification.
+
+## Best Practices
+
+1. **Clear issue contracts**: Well-defined `Required code outputs` and `Validation command` improve agent success
+2. **Use lane guides**: Follow [lane-guides/README.md](lane-guides/README.md) for language-specific expectations
+3. **Monitor recovery patterns**: Check [agent-remediation-playbook.md](agent-remediation-playbook.md) for repeated failure handling
+
+## Extending Agent Capabilities
+
+To add new agent features:
+
+1. Define new task kinds in `healer_task_spec.py`
+2. Add validation logic in `healer_runner.py`
+3. Update lane guides for new language/framework support
+4. Add tests in the matching `tests/test_healer_*.py` module
+
+## Related Documentation
+
+- [connectors.md](connectors.md) — All supported AI backends
+- [haiku.md](haiku.md) — Claude Haiku configuration
+- [automated-coding-with-claude-haiku.md](automated-coding-with-claude-haiku.md) — Deep dive on Haiku
+- [agent-remediation-playbook.md](agent-remediation-playbook.md) — Repeated failure handling

--- a/docs/haiku.md
+++ b/docs/haiku.md
@@ -1,0 +1,40 @@
+# Haiku
+
+Flow Healer uses Claude Haiku as one of its AI connector backends for automated code generation and repair.
+
+## Overview
+
+Claude Haiku is Anthropic's efficient large language model optimized for speed and cost-effectiveness. It's particularly well-suited for focused, deterministic repair tasks like fixing test failures, updating dependencies, and handling configuration changes.
+
+## Configuration
+
+To use Haiku as your connector, configure your `config.yaml`:
+
+```yaml
+service:
+  connector_backend: claude_cli  # or other Haiku-supported backends
+  connector_model: claude-haiku-4-5-20251001
+```
+
+## Use Cases
+
+Haiku-powered healing handles:
+- Test failure repairs
+- Dependency upgrade fixes
+- Configuration mismatches
+- Breaking API changes
+- Documentation updates
+
+## When to Use Haiku
+
+Haiku is ideal when:
+- Speed is important (fast inference)
+- Cost efficiency matters
+- Tasks are focused and deterministic
+- Large context is needed (200k window)
+
+## Related Documentation
+
+- [automated-coding-with-claude-haiku.md](automated-coding-with-claude-haiku.md) — Detailed guide on Claude Haiku integration
+- [connectors.md](connectors.md) — All supported AI backends
+- [agentic-coding.md](agentic-coding.md) — General agentic coding capabilities


### PR DESCRIPTION
Status: ✅ Done — move to dev-review
## Summary
Documentation is missing for Haiku functionality and agentic coding features in the `flow-healer` project.

## Problem
Users and contributors currently have no clear guidance on how to use or extend the Haiku and agentic coding capabilities. This makes it hard to understand the intended workflows, APIs, and best practices.

## Affected files / areas
- `docs/haiku.md` (missing)
- `docs/agentic-coding.md` (missing)
- `README.md` (lacks references)

## Evidence
- No dedicated documentation exists for Haiku or agentic coding in the repo.
- Users have asked for more clarity on these features in discussions.

## Why it matters
Without documentation, contributors cannot easily adopt or extend these features, which slows down development and can lead to misuse or inconsistent implementations.

## Suggested next step
Create new documentation pages for Haiku and agentic coding, update the README with links, and include examples or usage patterns.

## Acceptance criteria
- [ ] New `docs/haiku.md` and `docs/agentic-coding.md` files created
- [ ] README updated to reference the new documentation
- [ ] Examples or walkthroughs included in the docs
- [ ] Documentation reviewed and verified for accuracy

## Notes
Consider adding code snippets, simple use cases, and guidance for extending these features. #branch:issue-1279

Issue #1279